### PR TITLE
Remove Travis CI references from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
-# CWM Connect a Church Photo Directory System (Deprecated 2023)
-I will delete this project soon as it never got off the ground, and we need to focus on proclaiming.
-[![Build Status](https://travis-ci.com/Joomla-Bible-Study/joomla_churchdirectory.svg?branch=master)](https://travis-ci.com/Joomla-Bible-Study/joomla_churchdirectory)
+# CWM Connect — Church Photo Directory for Joomla 5/6
+
+[![CI](https://github.com/Joomla-Bible-Study/cwmconnect/actions/workflows/ci.yml/badge.svg)](https://github.com/Joomla-Bible-Study/cwmconnect/actions/workflows/ci.yml)
+
+`pkg_cwmconnect` is a Church Photo Directory component for Joomla 5/6, with a bundled birthday/anniversary site module and a Smart Search adapter for directory entries.
+
+The repository is in **active modernization** from its original Joomla 3.x / PHP 7.x codebase to Joomla 5/6 / PHP 8.3, mirroring the [Proclaim](https://github.com/Joomla-Bible-Study/Proclaim) layout and consuming [cwm-build-tools](https://github.com/Joomla-Bible-Study/cwm-build-tools) for build/release. Progress is tracked at [#77](https://github.com/Joomla-Bible-Study/cwmconnect/issues/77).
+
+For the project layout, target shape, command reference, and per-phase status, see [CLAUDE.md](CLAUDE.md).

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,5 +1,4 @@
 # Joomla Church Directory System Templates.
-[![Build Status](https://travis-ci.org/Joomla-Bible-Study/joomla_churchdirectory.svg?branch=master)](https://travis-ci.org/Joomla-Bible-Study/joomla_churchdirectory)
 
 ## About Templates
 We are working on new Templates.


### PR DESCRIPTION
## Remove Travis CI references from READMEs

Travis was wired into this repo via [`.travis.yml`](https://github.com/Joomla-Bible-Study/cwmconnect/blob/master/.travis.yml) + [`build/travis/`](https://github.com/Joomla-Bible-Study/cwmconnect/tree/master/build/travis), both of which [PR #88](https://github.com/Joomla-Bible-Study/cwmconnect/pull/88) (phase 1) deleted when CI moved to [`.github/workflows/ci.yml`](https://github.com/Joomla-Bible-Study/cwmconnect/blob/master/.github/workflows/ci.yml).

The READMEs still carried Travis build-status badges pointing at the dead `travis-ci.com` / `travis-ci.org` dashboards — those badges have shown stale/unknown status since phase 1 merged.

Refs #77

## What changed

### [README.md](README.md)

- Removed the Travis badge.
- Added a GitHub Actions CI badge pointing at the actual workflow.
- Replaced the title with the modernized project name + scope.
- Removed the "Deprecated 2023 — will delete soon" line. That sentence was true when the original author wrote it; it's actively misleading now that the modernization is in progress. The current state is "active modernization to Joomla 5/6", with progress tracked at [#77](https://github.com/Joomla-Bible-Study/cwmconnect/issues/77).
- Pointed at [CLAUDE.md](CLAUDE.md) for project layout / commands / phase status (which is already the canonical doc for that information).

### [templates/README.md](templates/README.md)

- Removed the Travis badge.

## Flagged but not done

`templates/` is now an empty folder except for the (still stale) README that says "We are working on new Templates." Joomla 5/6 components don't typically ship with bundled templates — that's a Joomla 1.5–era pattern. The whole `templates/` directory is dead weight and could be removed in a follow-up PR. Out of scope here since this PR is specifically the Travis cleanup directive.

## Verification

`grep -rli "travis"` against the working tree (excluding `.git/` and `libraries/`) returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
