### PR TITLE
Phase 5a: Bump minimum PHP to 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, json, xml, zip, curl, gd, fileinfo
           coverage: none
           tools: composer:v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project status
 
-cwmconnect is in **active modernization**: a Joomla 3.x / PHP 7.x component is being rewritten as a Joomla 5/6 / PHP 8.3 package (`pkg_cwmconnect`) following the [Proclaim](../Proclaim) layout and the [cwm-build-tools](../cwm-build-tools) toolchain (with [CWMScriptureLinks](../CWMScriptureLinks) and [CWMLivingWord](../CWMLivingWord) as the wire-in references).
+cwmconnect is in **active modernization**: a Joomla 3.x / PHP 7.x component is being rewritten as a Joomla 5/6 / PHP 8.4 package (`pkg_cwmconnect`) following the [Proclaim](../Proclaim) layout and the [cwm-build-tools](../cwm-build-tools) toolchain (with [CWMScriptureLinks](../CWMScriptureLinks) and [CWMLivingWord](../CWMLivingWord) as the wire-in references).
 
-The legacy Joomla 3 source still lives under [admin/](admin/), [site/](site/), [modules/site/mod_birthdayanniversary/](modules/site/mod_birthdayanniversary/), and [plugins/finder/churchdirectory/](plugins/finder/churchdirectory/) — that code does not run on Joomla 5/6 and will be migrated, not preserved, as the phases land. Treat existing classes as **migration source**, not as patterns to follow for new code.
+The legacy Joomla 3 source tree has been deleted in phases 4a–4d. Every component / module / plugin runtime path now lives under `admin/src/`, `site/src/`, `modules/site/mod_birthdayanniversary/src/`, and `plugins/finder/churchdirectory/src/`.
 
 ## Migration phases
 
@@ -17,20 +17,23 @@ The legacy Joomla 3 source still lives under [admin/](admin/), [site/](site/), [
 | 2 | Manifests: `<namespace>` + `<compatibility>` + `<scriptfile>script.php</scriptfile>` for component, module, finder plugin | done |
 | 3a | Dispatch infra: `admin/services/provider.php` + admin/site Dispatcher + Extension class | done |
 | 3b | Admin PSR-4 entities + singletons + helpers + HTML services + custom fields (all under `admin/src/`) | done |
-| 4a | Drop legacy admin entry stubs (`admin/api.php`, `admin/churchdirectory.php`, `admin/controller.php`) | **next** |
-| 4b | Port `site/` to PSR-4 under `site/src/` (Controller, Model, View, Helper, Router, Service) | pending |
-| 4c | Rewrite `mod_birthdayanniversary` with the J5 Dispatcher pattern (`modules/site/mod_birthdayanniversary/src/Dispatcher`) | pending |
-| 4d | Rewrite `plugins/finder/churchdirectory` as event subscriber (`SubscriberInterface`) | pending |
-| 5 | PHP 8.3 idioms (strict_types, type declarations, property promotion, readonly) | pending |
+| 4a | Drop legacy admin entry stubs (`admin/api.php`, `admin/churchdirectory.php`, `admin/controller.php`) | done |
+| 4b | Port `site/` to PSR-4 under `site/src/` (Controller, Model, View, Helper, Router, Service) | done |
+| 4c | Rewrite `mod_birthdayanniversary` with the J5 Dispatcher pattern | done |
+| 4d | Rewrite `plugins/finder/churchdirectory` as event subscriber (`SubscriberInterface`) | done |
+| 5a | PHP 8.4 minimum: composer.json + manifest `<php minimum>` + CI workflow | **next** |
+| 5b | `admin/src/` idioms: `declare(strict_types=1)`, tight type declarations, property promotion, `readonly`, PHP 8.4 features where they fit | pending |
+| 5c | `site/src/` idioms | pending |
+| 5d | Module + finder plugin idioms | pending |
 | 6 | Frontend: drop LESS pipeline, register WebAssets via `joomla.asset.json` | pending |
 | 7 | SQL: utf8mb4 + J5/J6 update files | pending |
-| 8 | Tests + CI parity (`tests/unit/`, J5×J6 × PHP 8.3×8.4 matrix) | pending |
+| 8 | Tests + CI parity (`tests/unit/`, J5×J6 × PHP 8.4 matrix) | pending |
 | 9 | Release plumbing: changelog XML, ARS category/stream IDs, updateservers | pending |
 
 ## Target shape (Proclaim-mirrored, unprefixed Joomla-standard naming)
 
 ```
-churchdirectory.xml                          # type=component, J5+J6, php 8.3
+churchdirectory.xml                          # type=component, J5+J6, php 8.4
 churchdirectory.script.php                   # rewritten for namespaced base
 admin/
   services/provider.php                      # registers MVCFactory + ComponentDispatcherFactory
@@ -61,7 +64,7 @@ build/
   build-package.php                          # zip builder                        ✅ phase 1 (stub)
   cwmconnect-changelog.xml                   # ← phase 9
 cwm-build.config.json                        # build-tools config                 ✅ phase 1
-composer.json                                # PHP 8.3 / PSR-4 / cwm/build-tools  ✅ phase 1
+composer.json                                # PHP 8.4 / PSR-4 / cwm/build-tools  ✅ phase 1
 .github/workflows/ci.yml                     # GH Actions                         ✅ phase 1
 ```
 

--- a/churchdirectory.xml
+++ b/churchdirectory.xml
@@ -16,7 +16,7 @@
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
         </cms>
-        <php minimum="8.3.0" />
+        <php minimum="8.4.0" />
     </compatibility>
 
     <scriptfile>script.php</scriptfile>

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.3.0"
+            "php": "8.4.0"
         },
         "vendor-dir": "libraries/vendor",
         "github-protocols": [
@@ -41,7 +41,7 @@
         }
     },
     "require": {
-        "php": "^8.3.0",
+        "php": "^8.4.0",
         "ext-mbstring": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
@@ -62,7 +62,8 @@
         "paragonie/random_compat": "9.99.99",
         "symfony/polyfill-php80": "*",
         "symfony/polyfill-php81": "*",
-        "symfony/polyfill-php82": "*"
+        "symfony/polyfill-php82": "*",
+        "symfony/polyfill-php83": "*"
     },
     "repositories": [
         {

--- a/modules/site/mod_birthdayanniversary/mod_birthdayanniversary.xml
+++ b/modules/site/mod_birthdayanniversary/mod_birthdayanniversary.xml
@@ -16,7 +16,7 @@
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
         </cms>
-        <php minimum="8.3.0" />
+        <php minimum="8.4.0" />
     </compatibility>
 
     <files>

--- a/plugins/finder/churchdirectory/churchdirectory.xml
+++ b/plugins/finder/churchdirectory/churchdirectory.xml
@@ -16,7 +16,7 @@
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
         </cms>
-        <php minimum="8.3.0" />
+        <php minimum="8.4.0" />
     </compatibility>
 
     <files>


### PR DESCRIPTION
## Summary

Phase 5a: Lock in **PHP 8.4 as the package minimum** before phase 5b/5c/5d start applying the 8.4 idioms (`declare(strict_types=1)`, tight type declarations, promotion, `readonly`, property hooks, asymmetric visibility, `array_find`/`array_any`/`array_all`).

This is a focused gate-only change — no idiom rewrites yet, just the version constraints.

## What landed

- **composer.json**:
  - `config.platform.php`: `8.3.0` → `8.4.0`
  - `require.php`: `^8.3.0` → `^8.4.0`
  - `replace`: add `symfony/polyfill-php83: "*"` so transitive deps that pull the 8.3 polyfill can be elided too
- **Manifests** (all three):
  - `churchdirectory.xml`
  - `modules/site/mod_birthdayanniversary/mod_birthdayanniversary.xml`
  - `plugins/finder/churchdirectory/churchdirectory.xml`
  - `<php minimum="8.3.0" />` → `<php minimum="8.4.0" />`
- **CI**: `.github/workflows/ci.yml` `php-version: '8.3'` → `'8.4'`
- **CLAUDE.md**:
  - Project-status sentence: `PHP 8.3` → `PHP 8.4`
  - Phase table: 4a–4d marked done (was overdue); phase 5 expanded into 5a/5b/5c/5d sub-phases; 5a marked next
  - Target-shape comments updated

## Why 8.4 now

- CWMScriptureLinks already requires `>=8.4`. Aligning here keeps the cwm-* repos converging.
- Joomla 5.x and 6.x both support PHP 8.4 (5.x: 8.1–8.4 supported; 6.x: 8.3+).
- 8.4 was released November 2024 — by May 2026 it's the default on every modern shared-hosting platform (cPanel, Plesk, PHP-FPM packagers).
- Phase 5b–5d wants to use property hooks, asymmetric visibility, the new array helpers — features that require 8.4 syntactically.

## Verification

- `composer install` clean against the new platform (recomputed content-hash; no package set change).
- `composer lint:syntax` passes — no 8.4-specific syntax slipped in yet.
- CI runs on 8.4 now; the existing parallel `php -l` step covers all PSR-4 files.

## Test plan

- [ ] CI green (`PHP Lint & Tests` on PHP 8.4)
- [ ] `composer install` still succeeds for downstream users (they'll need PHP 8.4)
- [ ] Manifests install cleanly on a J5/6 instance running PHP 8.4

## Follow-ups (phase 5b–5d)

- 5b: `admin/src/` — add `declare(strict_types=1)` and tighten all type declarations
- 5c: `site/src/` — same
- 5d: Module + finder plugin — same

🤖 Generated with [Claude Code](https://claude.ai/code)
