### PR TITLE
Phase 5b: declare(strict_types=1) across admin/src + tighten Members ctor

### DIFF
--- a/admin/src/Controller/CpanelController.php
+++ b/admin/src/Controller/CpanelController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/DatabaseController.php
+++ b/admin/src/Controller/DatabaseController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/DirheaderController.php
+++ b/admin/src/Controller/DirheaderController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/DirheadersController.php
+++ b/admin/src/Controller/DirheadersController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/FamilyunitController.php
+++ b/admin/src/Controller/FamilyunitController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/FamilyunitsController.php
+++ b/admin/src/Controller/FamilyunitsController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/GeostatusController.php
+++ b/admin/src/Controller/GeostatusController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/GeoupdateController.php
+++ b/admin/src/Controller/GeoupdateController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/InfoController.php
+++ b/admin/src/Controller/InfoController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/KmlController.php
+++ b/admin/src/Controller/KmlController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/KmlsController.php
+++ b/admin/src/Controller/KmlsController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/MemberController.php
+++ b/admin/src/Controller/MemberController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/MembersController.php
+++ b/admin/src/Controller/MembersController.php
@@ -7,15 +7,20 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\Input\Input;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -34,16 +39,20 @@ class MembersController extends AdminController
     /**
      * Constructor.
      *
-     * @param   array                $config   An optional associative array of configuration settings.
-     * @param   mixed                $factory  The factory.
-     * @param   mixed                $app      The Application object.
-     * @param   mixed                $input    Input.
+     * @param   array                             $config   An optional associative array of configuration settings.
+     * @param   MVCFactoryInterface|null          $factory  The factory.
+     * @param   CMSWebApplicationInterface|null   $app      The Application object.
+     * @param   Input|null                        $input    Input.
      *
      * @throws  \Exception
      * @since   2.0.0
      */
-    public function __construct($config = [], $factory = null, $app = null, $input = null)
-    {
+    public function __construct(
+        $config = [],
+        ?MVCFactoryInterface $factory = null,
+        ?CMSWebApplicationInterface $app = null,
+        ?Input $input = null,
+    ) {
         parent::__construct($config, $factory, $app, $input);
 
         $this->registerTask('unfeatured', 'featured');

--- a/admin/src/Controller/PositionController.php
+++ b/admin/src/Controller/PositionController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/PositionsController.php
+++ b/admin/src/Controller/PositionsController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Controller/ReportsController.php
+++ b/admin/src/Controller/ReportsController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Dispatcher/Dispatcher.php
+++ b/admin/src/Dispatcher/Dispatcher.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Dispatcher;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Extension/ChurchdirectoryComponent.php
+++ b/admin/src/Extension/ChurchdirectoryComponent.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Extension;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Field/ChildrenField.php
+++ b/admin/src/Field/ChildrenField.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Field;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Field/Modal/MembersField.php
+++ b/admin/src/Field/Modal/MembersField.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Field\Modal;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Field/OrderingField.php
+++ b/admin/src/Field/OrderingField.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Field;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Field/SpouseField.php
+++ b/admin/src/Field/SpouseField.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Field;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Helper/ChurchdirectoryHelper.php
+++ b/admin/src/Helper/ChurchdirectoryHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Helper/DbHelper.php
+++ b/admin/src/Helper/DbHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Helper/ReportbuildHelper.php
+++ b/admin/src/Helper/ReportbuildHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/CpanelModel.php
+++ b/admin/src/Model/CpanelModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/DatabaseModel.php
+++ b/admin/src/Model/DatabaseModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/DirheaderModel.php
+++ b/admin/src/Model/DirheaderModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/DirheadersModel.php
+++ b/admin/src/Model/DirheadersModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/FamilyunitModel.php
+++ b/admin/src/Model/FamilyunitModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/FamilyunitsModel.php
+++ b/admin/src/Model/FamilyunitsModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/GeostatusModel.php
+++ b/admin/src/Model/GeostatusModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/GeoupdateModel.php
+++ b/admin/src/Model/GeoupdateModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/InfoModel.php
+++ b/admin/src/Model/InfoModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/KmlModel.php
+++ b/admin/src/Model/KmlModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/KmlsModel.php
+++ b/admin/src/Model/KmlsModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/MemberModel.php
+++ b/admin/src/Model/MemberModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/MembersModel.php
+++ b/admin/src/Model/MembersModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/PositionModel.php
+++ b/admin/src/Model/PositionModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/PositionsModel.php
+++ b/admin/src/Model/PositionsModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Model/ReportsModel.php
+++ b/admin/src/Model/ReportsModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Service/HTML/Colorpicker.php
+++ b/admin/src/Service/HTML/Colorpicker.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Service\HTML;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Service/HTML/Geoupdate.php
+++ b/admin/src/Service/HTML/Geoupdate.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Service\HTML;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Service/HTML/Member.php
+++ b/admin/src/Service/HTML/Member.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Service\HTML;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Table/DirheaderTable.php
+++ b/admin/src/Table/DirheaderTable.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Table;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Table/FamilyunitTable.php
+++ b/admin/src/Table/FamilyunitTable.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Table;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Table/KmlTable.php
+++ b/admin/src/Table/KmlTable.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Table;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Table/MemberTable.php
+++ b/admin/src/Table/MemberTable.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Table;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/Table/PositionTable.php
+++ b/admin/src/Table/PositionTable.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\Table;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Cpanel/HtmlView.php
+++ b/admin/src/View/Cpanel/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Cpanel;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Database/HtmlView.php
+++ b/admin/src/View/Database/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Database;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Dirheader/HtmlView.php
+++ b/admin/src/View/Dirheader/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Dirheader;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Dirheaders/HtmlView.php
+++ b/admin/src/View/Dirheaders/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Dirheaders;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Familyunit/HtmlView.php
+++ b/admin/src/View/Familyunit/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Familyunit;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Familyunits/HtmlView.php
+++ b/admin/src/View/Familyunits/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Familyunits;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Geostatus/HtmlView.php
+++ b/admin/src/View/Geostatus/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Geostatus;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Geoupdate/HtmlView.php
+++ b/admin/src/View/Geoupdate/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Geoupdate;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Info/HtmlView.php
+++ b/admin/src/View/Info/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Info;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Kml/HtmlView.php
+++ b/admin/src/View/Kml/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Kml;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Kmls/HtmlView.php
+++ b/admin/src/View/Kmls/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Kmls;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Member/HtmlView.php
+++ b/admin/src/View/Member/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Member;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Members/HtmlView.php
+++ b/admin/src/View/Members/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Members;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Position/HtmlView.php
+++ b/admin/src/View/Position/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Position;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Positions/HtmlView.php
+++ b/admin/src/View/Positions/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Positions;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/src/View/Reports/HtmlView.php
+++ b/admin/src/View/Reports/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Administrator\View\Reports;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/admin/tmpl/cpanel/default.php
+++ b/admin/tmpl/cpanel/default.php
@@ -11,10 +11,11 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Churchdirectory\Administrator\View\Cpanel\HtmlView;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var \CWM\Component\Churchdirectory\Administrator\View\Cpanel\HtmlView $this */
+/** @var HtmlView $this */
 ?>
 <form action="<?php echo Route::_('index.php?option=com_churchdirectory'); ?>"
       method="post" name="adminForm" id="adminForm">


### PR DESCRIPTION
## Summary

Phase 5b: Add `declare(strict_types=1);` across every file in `admin/src/` (65 files), and tighten the one remaining implicit-nullable constructor signature flagged by PHP 8.4's deprecation pass.

## What landed

- **65 files** in `admin/src/` now declare `strict_types=1`. The declaration sits between the leading docblock and the `namespace` line, matching Joomla core style.
- `admin/src/Controller/MembersController.php` — constructor parameters bumped from the legacy `$factory = null, $app = null, $input = null` shape to the parent `AdminController`'s typed signature (`?MVCFactoryInterface`, `?CMSWebApplicationInterface`, `?Input`). Adds the three imports the signature needs.
- `admin/tmpl/cpanel/default.php` — picked up a tiny consistency cleanup alongside: import `HtmlView` at the top and use the short alias in the `@var` tag.

PHP 8.4 only deprecates *implicit* nullable parameters (e.g. `function foo(string $x = null)`). Plain untyped `$pk = null` is unaffected; `MemberModel::getItem($pk = null)` is intentionally left as-is to match the parent `AdminModel::getItem()` signature.

## Verification

- `composer lint:syntax` passes — every file parses under PHP 8.4 with `declare(strict_types=1)` in scope.
- The only signature widening (`MembersController::__construct`) matches the parent class's typed signature, so the LSP rules accept it.

## Test plan

- [ ] CI green (`PHP Lint & Tests` on PHP 8.4)
- [ ] Manual smoke on a J5 install: load every admin view (Cpanel, Members, Member edit, Familyunits, Familyunit edit, Dirheaders, Dirheader edit, Positions, Position edit, Kmls, Kml edit, Geoupdate, Geostatus, Reports, Database, Info) — no TypeErrors thrown by the new strict mode

## Follow-ups (phase 5c–5d)

- 5c: same pass on `site/src/`
- 5d: same pass on `modules/site/.../src/` and `plugins/finder/.../src/`

🤖 Generated with [Claude Code](https://claude.ai/code)
