### PR TITLE
Phase 5c: declare(strict_types=1) across site/src

### DIFF
--- a/site/src/Controller/DisplayController.php
+++ b/site/src/Controller/DisplayController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Controller/HomeController.php
+++ b/site/src/Controller/HomeController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Controller/MemberController.php
+++ b/site/src/Controller/MemberController.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Controller;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Dispatcher/Dispatcher.php
+++ b/site/src/Dispatcher/Dispatcher.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Dispatcher;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Helper/CategoriesHelper.php
+++ b/site/src/Helper/CategoriesHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Helper/DirectoryHeaderHelper.php
+++ b/site/src/Helper/DirectoryHeaderHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Helper/RenderHelper.php
+++ b/site/src/Helper/RenderHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Helper/RouteHelper.php
+++ b/site/src/Helper/RouteHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Model/CategoriesModel.php
+++ b/site/src/Model/CategoriesModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Model/CategoryModel.php
+++ b/site/src/Model/CategoryModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Model/DirectoryModel.php
+++ b/site/src/Model/DirectoryModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Model/FeaturedModel.php
+++ b/site/src/Model/FeaturedModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Model/HomeModel.php
+++ b/site/src/Model/HomeModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Model/MemberModel.php
+++ b/site/src/Model/MemberModel.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Model;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Rule/ChurchdirectoryEmailMessageRule.php
+++ b/site/src/Rule/ChurchdirectoryEmailMessageRule.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Rule;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Rule/ChurchdirectoryEmailRule.php
+++ b/site/src/Rule/ChurchdirectoryEmailRule.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Rule;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Rule/ChurchdirectoryEmailSubjectRule.php
+++ b/site/src/Rule/ChurchdirectoryEmailSubjectRule.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Rule;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Service/HTML/Icon.php
+++ b/site/src/Service/HTML/Icon.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Service\HTML;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/Service/Router.php
+++ b/site/src/Service/Router.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\Service;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Categories/HtmlView.php
+++ b/site/src/View/Categories/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Categories;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Category/FeedView.php
+++ b/site/src/View/Category/FeedView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Category;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Category/HtmlView.php
+++ b/site/src/View/Category/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Category;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Category/KmlView.php
+++ b/site/src/View/Category/KmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Category;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Directory/HtmlView.php
+++ b/site/src/View/Directory/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Directory;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Directory/KmlView.php
+++ b/site/src/View/Directory/KmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Directory;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Directory/PdfView.php
+++ b/site/src/View/Directory/PdfView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Directory;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Directory/XmlView.php
+++ b/site/src/View/Directory/XmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Directory;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Featured/HtmlView.php
+++ b/site/src/View/Featured/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Featured;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Home/HtmlView.php
+++ b/site/src/View/Home/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Home;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Member/HtmlView.php
+++ b/site/src/View/Member/HtmlView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Member;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/site/src/View/Member/VcfView.php
+++ b/site/src/View/Member/VcfView.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Component\Churchdirectory\Site\View\Member;
 
 // phpcs:disable PSR1.Files.SideEffects


### PR DESCRIPTION
## Summary

Phase 5c: Add `declare(strict_types=1);` across every file in `site/src/` (31 files). Same treatment as phase 5b for `admin/src/`.

## What landed

- **31 files** in `site/src/` now declare `strict_types=1` between the docblock and `namespace` line.
- No implicit-nullable parameters needed fixing — audited and clean.

## Verification

- `composer lint:syntax` passes on PHP 8.4.

## Test plan

- [ ] CI green
- [ ] Manual smoke on a J5 install: load home, featured, categories, category (HTML + Feed + KML), directory (home + search + KML), member (item + vCard download), enquiry-form submission — no TypeErrors

## Follow-ups

- 5d: same pass on `modules/site/.../src/` and `plugins/finder/.../src/`

🤖 Generated with [Claude Code](https://claude.ai/code)
