### PR TITLE
Phase 5d: declare(strict_types=1) across module + finder plugin (closes phase 5)

### DIFF
--- a/modules/site/mod_birthdayanniversary/src/Dispatcher/Dispatcher.php
+++ b/modules/site/mod_birthdayanniversary/src/Dispatcher/Dispatcher.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Module\Birthdayanniversary\Site\Dispatcher;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/modules/site/mod_birthdayanniversary/src/Helper/BirthdayanniversaryHelper.php
+++ b/modules/site/mod_birthdayanniversary/src/Helper/BirthdayanniversaryHelper.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Module\Birthdayanniversary\Site\Helper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/plugins/finder/churchdirectory/src/Extension/Churchdirectory.php
+++ b/plugins/finder/churchdirectory/src/Extension/Churchdirectory.php
@@ -7,6 +7,8 @@
  * @link       https://www.christianwebministries.org
  */
 
+declare(strict_types=1);
+
 namespace CWM\Plugin\Finder\Churchdirectory\Extension;
 
 // phpcs:disable PSR1.Files.SideEffects


### PR DESCRIPTION
## Summary

Phase 5d: Add `declare(strict_types=1);` across the bundled module + finder plugin. Closes phase 5.

Three files touched:
- `modules/site/mod_birthdayanniversary/src/Dispatcher/Dispatcher.php`
- `modules/site/mod_birthdayanniversary/src/Helper/BirthdayanniversaryHelper.php`
- `plugins/finder/churchdirectory/src/Extension/Churchdirectory.php`

No implicit-nullable parameters; `composer lint:syntax` clean.

After this lands, every PSR-4 file under `admin/src/`, `site/src/`, the bundled module, and the finder plugin opts into strict typing.

## Phase 5 wrap

| Phase | State |
|---|---|
| 5a | done (PHP 8.4 floor) |
| 5b | done (admin/src strict_types) |
| 5c | done (site/src strict_types) |
| 5d | this PR |

## Test plan

- [ ] CI green on PHP 8.4
- [ ] Module displays birthday/anniversary tables on a J5 install
- [ ] Finder indexer runs against the module; results render via the new template

🤖 Generated with [Claude Code](https://claude.ai/code)
