### PR TITLE
Phase 8: PHPUnit scaffolding + smoke test

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="libraries/vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="random"
+         resolveDependencies="true"
+         failOnWarning="true"
+         failOnRisky="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>admin/src</directory>
+            <directory>site/src</directory>
+            <directory>modules/site/mod_birthdayanniversary/src</directory>
+            <directory>plugins/finder/churchdirectory/src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PHPUnit bootstrap for the cwmconnect test suite.
+ *
+ * Loads Composer's PSR-4 autoload (covers the component, module, and
+ * plugin namespaces) and registers a small fall-through autoloader for
+ * the Joomla\CMS\* / Joomla\Event\* stubs under tests/stubs/. The stubs
+ * give the component classes just enough Joomla to be unit-testable
+ * outside a real Joomla install. Tests that need richer state should
+ * mock what they need locally rather than expanding the stub tree.
+ */
+
+require_once __DIR__ . '/../libraries/vendor/autoload.php';
+
+if (!\defined('_JEXEC')) {
+    \define('_JEXEC', 1);
+}
+
+if (!\defined('JPATH_LIBRARIES')) {
+    \define('JPATH_LIBRARIES', __DIR__ . '/../libraries');
+}
+
+if (!\defined('JPATH_ADMINISTRATOR')) {
+    \define('JPATH_ADMINISTRATOR', __DIR__ . '/stubs/administrator');
+}
+
+if (!\defined('JPATH_SITE')) {
+    \define('JPATH_SITE', __DIR__ . '/stubs/site');
+}
+
+/*
+ * Stub autoloader — only loads a class if (a) no other autoloader has
+ * already provided it, and (b) we have a matching file under
+ * tests/stubs/. Keeps stubs invisible when the real Joomla framework
+ * is on the include path.
+ */
+spl_autoload_register(static function (string $class): void {
+    $path = __DIR__ . '/stubs/' . str_replace('\\', '/', $class) . '.php';
+
+    if (is_file($path)) {
+        require_once $path;
+    }
+});

--- a/tests/stubs/Joomla/CMS/Language/Text.php
+++ b/tests/stubs/Joomla/CMS/Language/Text.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Joomla\CMS\Language;
+
+/**
+ * Test-only stub of Joomla\CMS\Language\Text. Returns the key unchanged
+ * for _() and a vsprintf'd version for sprintf(). Enough to let
+ * component classes that call Text::_ in initializers be instantiated
+ * in unit tests without a Joomla install.
+ */
+class Text
+{
+    public static function _(string $key): string
+    {
+        return $key;
+    }
+
+    public static function sprintf(string $key, ...$args): string
+    {
+        return vsprintf($key, $args);
+    }
+
+    public static function plural(string $key, int $n, ...$args): string
+    {
+        return $key;
+    }
+}

--- a/tests/unit/Helper/SmokeTest.php
+++ b/tests/unit/Helper/SmokeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Churchdirectory\Tests\Helper;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Smoke test that confirms the test harness wires up correctly:
+ *   - Composer autoload reaches the package's PSR-4 roots
+ *   - tests/bootstrap.php's stub autoloader resolves Joomla classes
+ *
+ * Failing this test means the suite as a whole is broken; failing
+ * any other test should be diagnosed independently.
+ *
+ * @since  2.0.0
+ */
+#[CoversNothing]
+final class SmokeTest extends TestCase
+{
+    public function testHarnessIsWiredUp(): void
+    {
+        self::assertTrue(\defined('_JEXEC'), '_JEXEC must be defined by tests/bootstrap.php');
+        self::assertTrue(\defined('JPATH_ADMINISTRATOR'), 'JPATH_ADMINISTRATOR must be defined by tests/bootstrap.php');
+        self::assertTrue(\defined('JPATH_SITE'), 'JPATH_SITE must be defined by tests/bootstrap.php');
+    }
+
+    public function testJoomlaTextStubResolves(): void
+    {
+        self::assertSame(
+            'COM_CHURCHDIRECTORY_DEMO_KEY',
+            \Joomla\CMS\Language\Text::_('COM_CHURCHDIRECTORY_DEMO_KEY'),
+            'The stubbed Joomla\\CMS\\Language\\Text::_ should echo the key unchanged.',
+        );
+
+        self::assertSame(
+            'hello world',
+            \Joomla\CMS\Language\Text::sprintf('hello %s', 'world'),
+            'The stubbed Text::sprintf should behave like vsprintf.',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 8: PHPUnit scaffolding. Lands a working test harness — `phpunit.xml`, `tests/bootstrap.php` with a PSR-4 stub autoloader for Joomla classes, and one smoke test that verifies both layers wire up correctly.

CLAUDE.md's phase 8 calls for "Tests + CI parity". This is the foundation; per-class tests can land incrementally once contributors have something to model on.

## What landed

**`phpunit.xml`**:
- `bootstrap = tests/bootstrap.php`
- `testsuite "unit"` → `tests/unit`
- `<source>` covers the four PSR-4 source roots (admin/src, site/src, module src, finder plugin src) so coverage runs scope themselves to package code
- `failOnWarning="true" failOnRisky="true" executionOrder="random"` — tighter defaults so flakes and hidden coupling surface early

**`tests/bootstrap.php`**:
- Loads Composer's PSR-4 autoload
- Defines `_JEXEC`, `JPATH_LIBRARIES`, `JPATH_ADMINISTRATOR`, `JPATH_SITE`
- Registers an `spl_autoload_register` that looks under `tests/stubs/` for any class not already resolved. Lets us define stand-alone stubs for `Joomla\CMS\*` classes without `eval()` (the CWMScriptureLinks pattern uses eval — clean stubs are nicer)

**`tests/stubs/Joomla/CMS/Language/Text.php`** — first stub:
- `_()` returns the key unchanged
- `sprintf()` does `vsprintf`
- `plural()` returns the key (good enough for smoke tests)

**`tests/unit/Helper/SmokeTest.php`** — two assertions:
- bootstrap-side constants are defined
- stub autoloader resolves `Joomla\CMS\Language\Text`

## Local verification

```
$ composer test
PHPUnit 12.5.24 by Sebastian Bergmann and contributors.
Runtime:       PHP 8.4.17
Configuration: /…/phpunit.xml
Random Seed:   1778593994

..                                                                  2 / 2 (100%)

Time: 00:00.001, Memory: 16.00 MB

OK (2 tests, 5 assertions)
```

## Test plan

- [ ] CI green (`composer check` runs lint:syntax + lint + test; the test step now actually runs PHPUnit)
- [ ] `composer test` locally on PHP 8.4 — same OK output

## Follow-ups

- Phase 9: release plumbing (changelog XML, ARS IDs, updateservers)
- Future PRs can grow the test suite — add a stub when a test demands it, write the test, ship.

🤖 Generated with [Claude Code](https://claude.ai/code)
