### PR TITLE
Mirror script.php into admin/ for symlinked dev installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build.properties
 
 # Dev-only convenience symlinks (see CLAUDE.md "Dev environment" section)
 /admin/churchdirectory.xml
+/admin/script.php

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -37,7 +37,8 @@
     "dev": {
         "_comment": "Drives cwm-link / cwm-link-check / cwm-clean / cwm-verify against the developer's local Joomla install(s). Component admin/site/media + the bundled module + finder plugin are auto-derived from manifests.extensions[]; the internalLinks entry replaces the manual `ln -s` step previously documented in CLAUDE.md.",
         "internalLinks": [
-            { "source": "churchdirectory.xml", "link": "admin/churchdirectory.xml" }
+            { "source": "churchdirectory.xml", "link": "admin/churchdirectory.xml" },
+            { "source": "script.php",          "link": "admin/script.php" }
         ]
     }
 }

--- a/script.php
+++ b/script.php
@@ -32,7 +32,7 @@ class Com_churchdirectoryInstallerScript
      *
      * @since  2.0.0
      */
-    protected string $minimumPhp = '8.3.0';
+    protected string $minimumPhp = '8.4.0';
 
     /**
      * Minimum Joomla version required.


### PR DESCRIPTION
## Summary
- Discover-install was failing on dev installs because Joomla resolves `<scriptfile>script.php</scriptfile>` relative to the manifest directory. When the component is symlinked (`administrator/components/com_churchdirectory -> admin/`), Joomla looks for `admin/script.php` — but `script.php` only existed at the repo root.
- Extend `cwm-build.config.json` `dev.internalLinks` so `composer link` mirrors `script.php` into `admin/` alongside the existing `churchdirectory.xml` mirror. Gitignore the new symlink to match.
- Bump `script.php::$minimumPhp` from `8.3.0` to `8.4.0` so preflight gating matches the manifest's `<php minimum="8.4.0">` set in phase 5a.

## Test plan
- [x] `composer clean && composer link` produces 5 outer + 2 internal symlinks in each install.
- [x] `administrator/components/com_churchdirectory/script.php` resolves to the repo `script.php`.
- [ ] Discover Install via Joomla admin UI registers the component and runs the install SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)