### PR TITLE
chore: bump cwm/build-tools to ^1.4 (stable)

### DIFF
--- a/build.dist.properties
+++ b/build.dist.properties
@@ -1,44 +1,85 @@
-# Build properties template for CWM Connect development
-# -------------------------------------------------------
-# This file is the canonical template. To customize for your environment:
+# ==============================================================================
+# build.dist.properties — auto-managed by `composer cwm-sync-configs`.
+# Do not edit by hand. To change defaults across all CWM repos, edit
+#   cwm-build-tools/templates/build.properties.tmpl
+# and re-run `composer cwm-sync-configs` in each consumer.
+# ==============================================================================
+#
+# Per-developer Joomla install configuration for cwm-build-tools dev commands.
+# This file is the per-developer mate to cwm-build.config.json:
+#   - cwm-build.config.json (committed) — what the project IS:
+#       extension layout, manifest paths, optional dev.links[].
+#   - build.properties (gitignored) — where YOUR dev environment runs:
+#       paths to your Joomla installs, DB credentials, admin credentials.
+#
+# To set up the first time:
 #   cp build.dist.properties build.properties
-# Then edit build.properties -- it is gitignored and never committed.
-# Or run: composer setup (interactive wizard)
+# Then either edit by hand or run the wizard:
+#   composer setup
+#
+# ALWAYS keep build.properties gitignored. It contains DB and admin passwords.
 
-# REQUIRED: Full path(s) to your Joomla installation(s)
-# Use builder.joomla_paths (plural) for multiple installations (comma-separated)
-# The singular builder.joomla_path is also supported for backward compatibility
-builder.joomla_paths=/path/to/joomla5,/path/to/joomla6
+# Default Joomla version (used by cwm-joomla-install when no per-install
+# version is set).
+joomla.version = 5.4.2
 
-# OPTIONAL: Subdirectory within each Joomla path -- usually empty.
-# This is appended to each entry in builder.joomla_paths by cwm-build-tools.
-builder.joomla_dir=
+# Comma-separated list of install ids. Each id must have a matching block
+# of `builder.<id>.*` keys below.
+builder.installs = j5, j6, j5-test
 
-# OPTIONAL: Absolute path to a Joomla CMS source clone used by the unit-test
-# bootstrap. If unset, defaults to ../joomla-cms relative to this repo and is
-# auto-created on `composer install`. Override only for non-standard layouts.
-tests.joomla_cms_path=
+# ----- Joomla 5 development install ----------------------------------------
+# role values:
+#   dev  — symlink-style working install. `cwm-link` deploys here.
+#   test — artifact-style install. `cwm-install-zip` deploys the dist zip
+#          here and `cwm-verify --target test` queries it.
+# (Default role is `dev` when omitted.)
+builder.j5.role        = dev
+builder.j5.path        = /path/to/joomla5
+builder.j5.url         = https://j5-dev.local
+builder.j5.version     = 5.4.2
+builder.j5.db_host     = localhost
+builder.j5.db_user     =
+builder.j5.db_pass     =
+builder.j5.db_name     =
+builder.j5.admin_user  = admin
+builder.j5.admin_pass  = admin
+builder.j5.admin_email = admin@example.com
 
-# Default Joomla version for testing and installation
-# When installing, you can choose a different version per path
-joomla.version=5.4.2
+# ----- Joomla 6 development install ----------------------------------------
+builder.j6.role        = dev
+builder.j6.path        = /path/to/joomla6
+builder.j6.url         = https://j6-dev.local
+builder.j6.version     = 6.0.0
+builder.j6.db_host     = localhost
+builder.j6.db_user     =
+builder.j6.db_pass     =
+builder.j6.db_name     =
+builder.j6.admin_user  = admin
+builder.j6.admin_pass  = admin
+builder.j6.admin_email = admin@example.com
 
-# Joomla 5 development site
-builder.j5dev.url=https://j5-dev.local:8890
-builder.j5dev.db_host=localhost
-builder.j5dev.db_user=
-builder.j5dev.db_pass=
-builder.j5dev.db_name=
-builder.j5dev.username=admin
-builder.j5dev.password=admin
-builder.j5dev.email=admin@example.com
+# ----- Joomla 5 test install (artifact verification) ----------------------
+# `cwm-install-zip` deploys the built dist zip into this install so you can
+# exercise the install scriptfile, manifest declarations, and schema
+# migrations end-to-end before release. Remove if you don't run a separate
+# test install — or delete j5-test from `builder.installs` above.
+builder.j5-test.role        = test
+builder.j5-test.path        = /path/to/joomla5-test
+builder.j5-test.url         = https://j5-test.local
+builder.j5-test.version     = 5.4.2
+builder.j5-test.db_host     = localhost
+builder.j5-test.db_user     =
+builder.j5-test.db_pass     =
+builder.j5-test.db_name     =
+builder.j5-test.admin_user  = admin
+builder.j5-test.admin_pass  = admin
+builder.j5-test.admin_email = admin@example.com
 
-# Joomla 6 development site
-builder.j6dev.url=https://j6-dev.local:8890
-builder.j6dev.db_host=localhost
-builder.j6dev.db_user=
-builder.j6dev.db_pass=
-builder.j6dev.db_name=
-builder.j6dev.username=admin
-builder.j6dev.password=admin
-builder.j6dev.email=admin@example.com
+# ----- CWM sibling paths --------------------------------------------------
+# Per-developer absolute paths to CWM siblings declared in
+# cwm-build.config.json under dev.cwmSiblings. Written by `composer setup`.
+# Key format: `paths.<composer-package-name>` (slashes are allowed in
+# Java-properties keys, so the composer name maps directly).
+#
+# paths.joomla-bible-study/lib-cwmscripture = /Users/you/GitHub/lib_cwmscripture
+# paths.cwm/scripture-links                 = /Users/you/GitHub/CWMScriptureLinks

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "typo3/phar-stream-wrapper": "^3.1.7"
     },
     "require-dev": {
-        "cwm/build-tools": "^0.5.5@alpha",
+        "cwm/build-tools": "^1.4",
         "phpunit/phpunit": "^12.5",
         "friendsofphp/php-cs-fixer": "^3.0",
         "roave/security-advisories": "dev-latest"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1f7846f31395d883f2c376c9c25ee5a",
+    "content-hash": "c1ea7f63c138dc4aa2a57e0b639c482c",
     "packages": [
         {
             "name": "google/recaptcha",
@@ -404,16 +404,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v0.5.5-alpha",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "aafadd9cb4b1382df41d7be40c29da0d253b2328"
+                "reference": "fb8409262f54290528fa0d162abcdc003b864d51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/aafadd9cb4b1382df41d7be40c29da0d253b2328",
-                "reference": "aafadd9cb4b1382df41d7be40c29da0d253b2328",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/fb8409262f54290528fa0d162abcdc003b864d51",
+                "reference": "fb8409262f54290528fa0d162abcdc003b864d51",
                 "shasum": ""
             },
             "require": {
@@ -444,6 +444,7 @@
                 "bin/cwm-link-check",
                 "bin/cwm-clean",
                 "bin/cwm-verify",
+                "bin/cwm-install-zip",
                 "bin/cwm-joomla-install",
                 "bin/cwm-joomla-latest",
                 "bin/cwm-joomla-cms-deps"
@@ -498,10 +499,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v0.5.5-alpha",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.4.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-05-12T14:48:33+00:00"
+            "time": "2026-05-15T20:36:27+00:00"
         },
         {
             "name": "ergebnis/agent-detector",
@@ -682,16 +683,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.1",
+            "version": "v3.95.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065"
+                "reference": "a28d88a5e172b27e78d0816992b15a9df3da20f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a9727678fbd12997f1d9de8f4a37824ed9df1065",
-                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a28d88a5e172b27e78d0816992b15a9df3da20f1",
+                "reference": "a28d88a5e172b27e78d0816992b15a9df3da20f1",
                 "shasum": ""
             },
             "require": {
@@ -723,8 +724,8 @@
                 "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
-                "infection/infection": "^0.32.6",
+                "facile-it/paraunit": "^1.3.1 || ^2.11.0",
+                "infection/infection": "^0.32.7",
                 "justinrainbow/json-schema": "^6.8.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
@@ -775,7 +776,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.2"
             },
             "funding": [
                 {
@@ -783,7 +784,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-12T17:00:09+00:00"
+            "time": "2026-05-15T09:20:44+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1368,16 +1369,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.24",
+            "version": "12.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d75dd30597caa80e72fad2ef7904601a30ef1046"
+                "reference": "792c2980442dfce319226b88fa845b8b6de3b333"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d75dd30597caa80e72fad2ef7904601a30ef1046",
-                "reference": "d75dd30597caa80e72fad2ef7904601a30ef1046",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/792c2980442dfce319226b88fa845b8b6de3b333",
+                "reference": "792c2980442dfce319226b88fa845b8b6de3b333",
                 "shasum": ""
             },
             "require": {
@@ -1446,7 +1447,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.25"
             },
             "funding": [
                 {
@@ -1454,7 +1455,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-01T04:21:04+00:00"
+            "time": "2026-05-13T03:56:57+00:00"
         },
         {
             "name": "psr/container",
@@ -2141,12 +2142,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "ec0c867c22e5b8d392815d48e4cc9de37470e8c0"
+                "reference": "80f4d3dbb1fc1ef5bb1eee68dbfb44060e1fb4e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/ec0c867c22e5b8d392815d48e4cc9de37470e8c0",
-                "reference": "ec0c867c22e5b8d392815d48e4cc9de37470e8c0",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/80f4d3dbb1fc1ef5bb1eee68dbfb44060e1fb4e8",
+                "reference": "80f4d3dbb1fc1ef5bb1eee68dbfb44060e1fb4e8",
                 "shasum": ""
             },
             "conflict": {
@@ -2267,7 +2268,7 @@
                 "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
                 "co-stack/fal_sftp": "<0.2.6",
                 "cockpit-hq/cockpit": "<2.14",
-                "code16/sharp": "<9.20",
+                "code16/sharp": "<9.22",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.10",
                 "codeigniter4/framework": "<4.6.2",
@@ -2277,7 +2278,7 @@
                 "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
                 "commerceteam/commerce": ">=0.9.6,<0.9.9",
                 "components/jquery": ">=1.0.3,<3.5",
-                "composer/composer": "<2.2.27|>=2.3,<2.9.6",
+                "composer/composer": "<2.2.28|>=2.3,<2.9.8",
                 "concrete5/concrete5": "<9.4.8",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
@@ -2287,7 +2288,7 @@
                 "contao/core-bundle": "<4.13.57|>=5,<5.3.42|>=5.4,<5.6.5",
                 "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
-                "coreshop/core-shop": "<4.1.9",
+                "coreshop/core-shop": "<4.1.9|==5",
                 "corveda/phpsandbox": "<1.3.5",
                 "cosenary/instagram": "<=2.3",
                 "couleurcitron/tarteaucitron-wp": "<0.3",
@@ -2467,7 +2468,7 @@
                 "georgringer/news": "<1.3.3",
                 "geshi/geshi": "<=1.0.9.1",
                 "getformwork/formwork": "<=2.3.3",
-                "getgrav/grav": "<2.0.0.0-beta4",
+                "getgrav/grav": "<=2.0.0.0-RC1",
                 "getgrav/grav-plugin-api": "<1.0.0.0-beta15",
                 "getgrav/grav-plugin-form": "<9.1",
                 "getkirby/cms": "<4.9|>=5,<5.4",
@@ -2891,6 +2892,7 @@
                 "simplesamlphp/saml2": "<=4.16.15|>=5.0.0.0-alpha1,<=5.0.0.0-alpha19",
                 "simplesamlphp/saml2-legacy": "<=4.16.15",
                 "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/simplesamlphp-module-casserver": "<=7.0.2",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "simplesamlphp/simplesamlphp-module-openid": "<1",
                 "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
@@ -3199,7 +3201,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T19:35:52+00:00"
+            "time": "2026-05-15T18:36:41+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4152,16 +4154,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.0.9",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d"
+                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7113778e2e91f4709cb3194a75dfa9c0d028d94d",
-                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3156577f46a38aa1b9323aad223de7a9cd426782",
+                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782",
                 "shasum": ""
             },
             "require": {
@@ -4218,7 +4220,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.0.9"
+                "source": "https://github.com/symfony/console/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -4238,7 +4240,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T15:02:55+00:00"
+            "time": "2026-05-13T12:07:53+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4478,16 +4480,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.9",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40"
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40",
-                "reference": "d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7",
                 "shasum": ""
             },
             "require": {
@@ -4524,7 +4526,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.9"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -4544,7 +4546,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:51:42+00:00"
+            "time": "2026-05-11T16:39:47+00:00"
         },
         {
             "name": "symfony/finder",
@@ -5102,16 +5104,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.8",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
+                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
-                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "url": "https://api.github.com/repos/symfony/process/zipball/26d89e459f037d2873300605d0a07e7a8ef84db0",
+                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0",
                 "shasum": ""
             },
             "require": {
@@ -5143,7 +5145,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.8"
+                "source": "https://github.com/symfony/process/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -5163,7 +5165,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-11T16:56:32+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5320,16 +5322,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.8",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+                "url": "https://api.github.com/repos/symfony/string/zipball/39be2ad058a3c0bd558edca23e65f009865d75ff",
+                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff",
                 "shasum": ""
             },
             "require": {
@@ -5386,7 +5388,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.8"
+                "source": "https://github.com/symfony/string/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -5406,7 +5408,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-13T12:07:53+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5462,7 +5464,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "cwm/build-tools": 15,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
## Summary
- Bumps `cwm/build-tools` from `^0.5.5@alpha` to `^1.4` (now stable, matches CWMScriptureLinks pin).
- Regenerates `build.dist.properties` via `composer sync-configs` to the new v1.4 auto-managed canonical shape: flat keys with `builder.installs` list, per-id `role`/`path`/`version`/`admin_user`/`admin_pass`/`admin_email` keys, and `paths.<composer-package>` for cwmSiblings.
- Drops alpha stability flag from `composer.lock`; installs v1.4.0.

## Notes
- v1.4.0 is non-breaking for `build.properties` readers — pre-existing local files using the old `builder.joomla_paths=...` flat shape still parse (per upstream CHANGELOG).
- No source changes: `composer.json` scripts already alias to `cwm-*` binaries.
- Unrelated working-tree noise (4-space reformat of `media/com_cwmconnect/joomla.asset.json`) was reverted before this commit.

## Test plan
- [x] `composer install` clean
- [x] `composer lint:syntax` passes
- [x] `composer test` passes (2 tests, 5 assertions)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)