### PR TITLE
Phase A: data model — PC sync columns + feed-tokens table

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -5,7 +5,14 @@ SET SQL_MODE = '';
 --
 
 CREATE TABLE IF NOT EXISTS `#__cwmconnect_details` (
-  `id`               INT(11)             NOT NULL AUTO_INCREMENT,
+  `id`                   INT(11)                                NOT NULL AUTO_INCREMENT,
+  `pc_person_id`         BIGINT                                 NULL,
+  `pc_last_synced_at`    DATETIME                               NULL,
+  `display_in_directory` TINYINT(1)                             NOT NULL DEFAULT 1,
+  `directory_scope`      ENUM('public', 'household', 'hidden')  NOT NULL DEFAULT 'public',
+  `pc_shared_info`       JSON                                   NULL,
+  `image_filename`       VARCHAR(255)                           NULL,
+  `image_hash`           VARCHAR(64)                            NULL,
   `name`             VARCHAR(255)        NOT NULL DEFAULT '',
   `lname`            VARCHAR(255)        NOT NULL DEFAULT '',
   `alias`            VARCHAR(255)        NOT NULL DEFAULT '',
@@ -68,6 +75,7 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_details` (
   `mstatus`          TINYINT(3)          NOT NULL DEFAULT '0'
   COMMENT 'Used to track Members Status',
   PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_pc_person_id` (`pc_person_id`),
   KEY `idx_catid` (`catid`),
   KEY `idx_access` (`access`),
   KEY `Idx_checkout` (`checked_out`),
@@ -77,7 +85,9 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_details` (
   KEY `idx_language` (`language`),
   KEY `idx_xreference` (`xreference`),
   KEY `idx_kmlid` (`kmlid`),
-  KEY `idx_funit` (`funitid`)
+  KEY `idx_funit` (`funitid`),
+  KEY `idx_display_in_directory` (`display_in_directory`),
+  KEY `idx_directory_scope` (`directory_scope`)
 )
   ENGINE =InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -401,3 +411,29 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_update` (
 
 INSERT INTO `#__cwmconnect_update` (`id`, `version`) VALUES
   (1, '1.8.2');
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `#__cwmconnect_feed_tokens`
+--
+-- Per-user revocable tokens for member self-service KML feed URLs
+-- (Phase I). One row per token; the secret is shown to the user once
+-- at issue and never stored — only its SHA-256 hash lives here.
+--
+
+CREATE TABLE IF NOT EXISTS `#__cwmconnect_feed_tokens` (
+  `id`           INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id`      INT UNSIGNED NOT NULL,
+  `token_hash`   CHAR(64)     NOT NULL,
+  `label`        VARCHAR(120) NOT NULL,
+  `created_at`   DATETIME     NOT NULL,
+  `last_used_at` DATETIME     NULL,
+  `revoked_at`   DATETIME     NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_token_hash` (`token_hash`),
+  KEY `idx_user_id` (`user_id`)
+)
+  ENGINE          = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  DEFAULT COLLATE = utf8mb4_unicode_ci;

--- a/admin/sql/uninstall.mysql.utf8.sql
+++ b/admin/sql/uninstall.mysql.utf8.sql
@@ -1,6 +1,7 @@
 DROP TABLE IF EXISTS `#__cwmconnect_details`;
 DROP TABLE IF EXISTS `#__cwmconnect_dirheader`;
 DROP TABLE IF EXISTS `#__cwmconnect_familyunit`;
+DROP TABLE IF EXISTS `#__cwmconnect_feed_tokens`;
 DROP TABLE IF EXISTS `#__cwmconnect_geoupdate`;
 DROP TABLE IF EXISTS `#__cwmconnect_kml`;
 DROP TABLE IF EXISTS `#__cwmconnect_position`;

--- a/admin/sql/updates/mysql/2.0.0-20260515.sql
+++ b/admin/sql/updates/mysql/2.0.0-20260515.sql
@@ -1,0 +1,58 @@
+--
+-- Phase A: v2 data model — additive columns + feed-tokens table.
+--
+-- Lands the schema surface that later v2 phases (B sync core, E photos,
+-- I KML feed, K admin print) need to exist. Plain ALTER / CREATE, no
+-- IF NOT EXISTS guards: Joomla's schema tracker runs each update file
+-- once per registered version, so re-runs are not the contract here.
+--
+-- Existing admin (member edit form, members list, etc.) continues to
+-- work unchanged — every new column has a safe default and existing
+-- code doesn't reference any of them yet.
+--
+-- Deferred to Phase H (member portal / identity binding):
+--   - `user_id` shape change from `INT(11) NOT NULL DEFAULT 0` to
+--     `INT UNSIGNED NULL UNIQUE`. The existing MemberTable still coerces
+--     unset user_id to 0; adding UNIQUE now would collide on the legacy
+--     fleet. The transform lands alongside MemberTable / MemberModel
+--     updates in Phase H.
+--
+
+SET SQL_MODE = '';
+
+--
+-- #__cwmconnect_details: Planning Center sync, privacy tiers, photo cache.
+--
+
+ALTER TABLE `#__cwmconnect_details`
+    ADD COLUMN `pc_person_id`         BIGINT                                       NULL          AFTER `id`,
+    ADD COLUMN `pc_last_synced_at`    DATETIME                                     NULL          AFTER `pc_person_id`,
+    ADD COLUMN `display_in_directory` TINYINT(1)                                   NOT NULL DEFAULT 1,
+    ADD COLUMN `directory_scope`      ENUM('public', 'household', 'hidden')        NOT NULL DEFAULT 'public',
+    ADD COLUMN `pc_shared_info`       JSON                                         NULL,
+    ADD COLUMN `image_filename`       VARCHAR(255)                                 NULL,
+    ADD COLUMN `image_hash`           VARCHAR(64)                                  NULL,
+    ADD UNIQUE INDEX `uniq_pc_person_id` (`pc_person_id`),
+    ADD INDEX `idx_display_in_directory` (`display_in_directory`),
+    ADD INDEX `idx_directory_scope` (`directory_scope`);
+
+--
+-- #__cwmconnect_feed_tokens: per-user revocable tokens for member self-service
+-- KML feed URLs (Phase I). One row per token; never re-displayed after issue.
+--
+
+CREATE TABLE IF NOT EXISTS `#__cwmconnect_feed_tokens` (
+    `id`           INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `user_id`      INT UNSIGNED NOT NULL,
+    `token_hash`   CHAR(64)     NOT NULL,
+    `label`        VARCHAR(120) NOT NULL,
+    `created_at`   DATETIME     NOT NULL,
+    `last_used_at` DATETIME     NULL,
+    `revoked_at`   DATETIME     NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uniq_token_hash` (`token_hash`),
+    KEY `idx_user_id` (`user_id`)
+)
+    ENGINE          = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    DEFAULT COLLATE = utf8mb4_unicode_ci;


### PR DESCRIPTION
Closes part of #111 (v2 tracker — Phase A).

## Summary
- Adds 7 columns to `#__cwmconnect_details` for Planning Center sync, three-tier privacy gates, and photo cache.
- Adds new `#__cwmconnect_feed_tokens` table for per-user revocable KML feed URLs.
- Updates both `install.mysql.utf8.sql` (fresh installs) and a new dated update file at `admin/sql/updates/mysql/2.0.0-20260515.sql` (upgrades).

## What lands

`#__cwmconnect_details` gains:
| Column | Type | Purpose |
|---|---|---|
| `pc_person_id` | `BIGINT NULL UNIQUE` | PC People FK; null on local-only records |
| `pc_last_synced_at` | `DATETIME NULL` | when sync last touched the row |
| `display_in_directory` | `TINYINT(1) DEFAULT 1` | master visibility gate (also hides children/opt-outs) |
| `directory_scope` | `ENUM('public','household','hidden') DEFAULT 'public'` | second-tier privacy gate |
| `pc_shared_info` | `JSON NULL` | per-field PC share preferences |
| `image_filename` | `VARCHAR(255) NULL` | path under `media/com_cwmconnect/photos/` |
| `image_hash` | `VARCHAR(64) NULL` | PC avatar URL hash for change detection |

Plus supporting indexes on the two visibility gates.

New table `#__cwmconnect_feed_tokens`: stores SHA-256 hashes only — never the raw secret.

## Deferred from spec §4

The `user_id` shape change (INT(11) NOT NULL DEFAULT 0 → INT UNSIGNED NULL UNIQUE) is held for **Phase H**. Existing `MemberTable::store()` coerces unset user_id to 0; adding UNIQUE now would collide on legacy rows. The transform lands alongside the MemberTable / MemberModel rewrite when the member portal arrives.

## Compatibility

Existing admin (member edit form, members list, batch ops, etc.) continues to work unchanged. New columns have safe defaults and zero existing-code references.

## Test plan
- [x] `composer lint:syntax` passes
- [x] `composer test` passes (2 tests, 5 assertions)
- [ ] CI green on this PR
- [ ] Manual: install on fresh J5/J6 → tables created with new shape (will exercise after merge against `j5-dev` / `j6-dev`)
- [ ] Manual: upgrade from pre-Phase-A install → update file runs, columns appear (will exercise after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)