### PR TITLE
chore: wire cwm-build-tools versionTracking profile (component)

### DIFF
--- a/build/media_source/com_cwmconnect/js/admin-pc-sync.es6.js
+++ b/build/media_source/com_cwmconnect/js/admin-pc-sync.es6.js
@@ -4,7 +4,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  * @link       https://www.christianwebministries.org
  *
- * @since   __DEPLOY_VERSION__
+ * @since   2.0.0
  */
 
 /**

--- a/build/versions.json
+++ b/build/versions.json
@@ -1,0 +1,22 @@
+{
+    "_comment": "Development version state. Updated by cwm-release after each release. Source of truth for @since tags during active development.",
+    "_updated": "2026-05-15",
+    "current": {
+        "version": "1.8.3",
+        "description": "Last stable release (final Joomla 3 line before the J5/6 modernisation)"
+    },
+    "next": {
+        "patch": "2.0.1",
+        "minor": "2.1.0",
+        "major": "3.0.0"
+    },
+    "active_development": {
+        "version": "2.0.0",
+        "description": "Use this for @since tags and migrations during in-progress work"
+    },
+    "notes": {
+        "patch": "Bug fixes only, no new features",
+        "minor": "New features, backward compatible",
+        "major": "Breaking changes"
+    }
+}

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -1,5 +1,12 @@
 {
     "_comment": "All three manifests bump in lockstep on a cwmconnect release: the component, the bundled site module, and the bundled finder plugin. The component is the primary surface; the module + finder plugin only ship from this repo and have no independent release cadence. ARS categoryId/updateStreamId are placeholders — populate before first release (run `cwm-ars-list` against the CWM ARS site to discover IDs).",
+    "_profile_comment": "Component-shaped versionTracking despite the package wrapper — cwmconnect owns its own versions.json + package.json on a single cadence. The substituteTokens.paths override drops 'language/' (cwmconnect has no top-level language/ dir; language files live under admin/language, site/language, modules/site/mod_birthdayanniversary/language, and plugins/finder/cwmconnect/language — all reached via the admin/, site/, modules/, plugins/ scan roots).",
+    "profile": "component",
+    "versionTracking": {
+        "substituteTokens": {
+            "paths": ["admin/", "site/", "modules/", "plugins/"]
+        }
+    },
     "extension": {
         "type": "package",
         "name": "pkg_cwmconnect"


### PR DESCRIPTION
## Summary
Activates `__DEPLOY_VERSION__` substitution + `versions.json` / `package.json` tracking via the cwm-build-tools `component` profile. Without this, the `@since __DEPLOY_VERSION__` tags landed in Phase A/B/C would ship as literal strings in built zips.

## What lands
- **`cwm-build.config.json`** — adds `"profile": "component"` plus an inline `versionTracking.substituteTokens.paths` override that drops the profile-default `language/` (cwmconnect has no top-level `language/` dir — language files live under `admin/language`, `site/language`, the module's `language`, and the plugin's `language`, all reached via the `admin/`, `site/`, `modules/`, `plugins/` scan roots).
- **`build/versions.json`** — new. `current` = 1.8.3 (last Joomla 3 stable), `active_development` = 2.0.0, semver bump targets at 2.0.1 / 2.1.0 / 3.0.0.
- **`build/media_source/com_cwmconnect/js/admin-pc-sync.es6.js`** — drops `@since __DEPLOY_VERSION__` for hardcoded `@since 2.0.0`. JS isn't in the substituter's default file-extension set (only `.php`); Proclaim's convention is to hardcode JS @since values, so keeping the substituter scope tight to PHP is the simpler call.

## Verification
```
$ php libraries/vendor/cwm/build-tools/scripts/resolve-tracking.php versionsJson
build/versions.json

$ php libraries/vendor/cwm/build-tools/scripts/resolve-tracking.php packageJson
package.json

$ php libraries/vendor/cwm/build-tools/scripts/resolve-tracking.php substituteTokens.token
__DEPLOY_VERSION__
```

Full resolved block:
```json
{
    "versionsJson": "build/versions.json",
    "packageJson":  "package.json",
    "substituteTokens": {
        "token":      "__DEPLOY_VERSION__",
        "paths":      ["admin/", "site/", "modules/", "plugins/"],
        "extensions": ["php"]
    }
}
```

Substitution scope: **9 PHP files** currently carry the placeholder, all under `admin/src/`:
- `admin/src/Controller/CpanelController.php`
- `admin/src/View/Cpanel/HtmlView.php`
- 7 files under `admin/src/Service/Pc/`

## Test plan
- [x] resolver returns expected keys + paths
- [x] `composer test` — 48 tests, 101 assertions pass
- [x] `composer lint:syntax` — clean
- [x] `npm run lint` — clean
- [x] `npm run build:js` — same artifacts as before, no diff in built `.js` (the `.es6.js` change is in the docblock header only)
- [ ] CI green
- [ ] Manual after merge: `composer release --dry-run` (or equivalent gate-check) — confirms versionTracking resolves and substitution would walk the right files

🤖 Generated with [Claude Code](https://claude.com/claude-code)