### PR TITLE
Phase E: PC avatar download + local photo cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ composer.phar
 /media/com_cwmconnect/css/
 /media/com_cwmconnect/js/
 
+# Phase E: PC avatar cache (runtime artifacts, re-downloaded by sync)
+/media/com_cwmconnect/photos/
+
 *.zip
 
 # Dev-only convenience symlinks (see CLAUDE.md "Dev environment" section)

--- a/admin/services/provider.php
+++ b/admin/services/provider.php
@@ -17,8 +17,10 @@ use CWM\Component\Cwmconnect\Administrator\Service\Pc\DatabaseMemberRepository a
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\Exception\ConfigurationException as PcConfigurationException;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\FieldMapRepositoryInterface as PcFieldMapRepositoryInterface;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\FieldsHelperWriter as PcFieldsHelperWriter;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\MediaPhotoCache as PcMediaPhotoCache;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\MemberRepositoryInterface as PcMemberRepositoryInterface;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\PersonMapper as PcPersonMapper;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\PhotoCacheInterface as PcPhotoCacheInterface;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\SyncEngine as PcSyncEngine;
 use Joomla\CMS\Categories\CategoryFactoryInterface;
 use Joomla\CMS\Component\ComponentHelper;
@@ -113,6 +115,17 @@ return new class implements ServiceProviderInterface {
             static fn(): PcCustomFieldWriterInterface => new PcFieldsHelperWriter(),
         );
 
+        // Phase E: avatar cache. Resolves the cache root at request time so
+        // a relocated Joomla install (JPATH_ROOT change after a move) keeps
+        // pointing at the right photos directory.
+        $container->set(
+            PcPhotoCacheInterface::class,
+            static fn(): PcPhotoCacheInterface => new PcMediaPhotoCache(
+                http: HttpFactory::getHttp(),
+                cacheRoot: JPATH_ROOT . '/media/com_cwmconnect/photos',
+            ),
+        );
+
         $container->set(
             PcSyncEngine::class,
             static fn(Container $c): PcSyncEngine => new PcSyncEngine(
@@ -121,6 +134,7 @@ return new class implements ServiceProviderInterface {
                 mapper: $c->get(PcPersonMapper::class),
                 fieldMapRepo: $c->get(PcFieldMapRepositoryInterface::class),
                 fieldWriter: $c->get(PcCustomFieldWriterInterface::class),
+                photoCache: $c->get(PcPhotoCacheInterface::class),
             ),
         );
     }

--- a/admin/src/Service/Pc/DatabaseMemberRepository.php
+++ b/admin/src/Service/Pc/DatabaseMemberRepository.php
@@ -156,6 +156,35 @@ final class DatabaseMemberRepository implements MemberRepositoryInterface
         return $existing === null ? null : $existing['id'];
     }
 
+    public function updateImageByPcPersonId(int $pcPersonId, string $relativePath, string $hash): void
+    {
+        $query = $this->db->getQuery(true)
+            ->update($this->db->quoteName(self::TABLE))
+            ->set([
+                $this->db->quoteName('image') . ' = :image',
+                $this->db->quoteName('image_hash') . ' = :hash',
+            ])
+            ->where($this->db->quoteName('pc_person_id') . ' = :pcPersonId')
+            ->bind(':image', $relativePath, ParameterType::STRING)
+            ->bind(':hash', $hash, ParameterType::STRING)
+            ->bind(':pcPersonId', $pcPersonId, ParameterType::INTEGER);
+
+        $this->db->setQuery($query)->execute();
+    }
+
+    public function findImageHashByPcPersonId(int $pcPersonId): ?string
+    {
+        $query = $this->db->getQuery(true)
+            ->select($this->db->quoteName('image_hash'))
+            ->from($this->db->quoteName(self::TABLE))
+            ->where($this->db->quoteName('pc_person_id') . ' = :pcPersonId')
+            ->bind(':pcPersonId', $pcPersonId, ParameterType::INTEGER);
+
+        $hash = $this->db->setQuery($query)->loadResult();
+
+        return \is_string($hash) && $hash !== '' ? $hash : null;
+    }
+
     /**
      * Look up the id + archive state of an existing row by PC person id.
      *

--- a/admin/src/Service/Pc/MediaPhotoCache.php
+++ b/admin/src/Service/Pc/MediaPhotoCache.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Administrator\Service\Pc;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\Exception\PcException;
+use Joomla\CMS\Http\Http;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Phase E: production `PhotoCacheInterface` that stores avatars under
+ * `media/com_cwmconnect/photos/`.
+ *
+ * Hash strategy: SHA-256 of the source URL itself. PC bakes the avatar
+ * version into the URL path (e.g. `/uploads/.../abc123.png?v=…`), so two
+ * different URLs guarantee two different photos — we don't need to fetch
+ * bytes just to diff. Per Decision #13 in the spec.
+ *
+ * Placeholder skip: PC returns `demographic_avatar_url` for everyone
+ * (initials-on-coloured-circle). We treat that as "no photo" so the cache
+ * doesn't fill with hundreds of identical-but-named placeholders. The
+ * detection is path-based — anything under `/static/` or with
+ * `demographic_avatar` in the URL is skipped.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class MediaPhotoCache implements PhotoCacheInterface
+{
+    /**
+     * Max accepted Content-Length / body size for an avatar download.
+     * PC avatars top out well under 1MB; we cap at 5MB so a
+     * configuration mistake or proxy-returned HTML page can't fill the
+     * disk. Bytes over the cap are dropped and the call returns null.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const MAX_BYTES = 5 * 1024 * 1024;
+
+    /**
+     * Allow-listed extensions derived from URL path. Anything outside
+     * this set falls back to `.jpg` (PC's most common avatar format) so
+     * we never write an executable or unknown blob to the photos dir.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const SAFE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
+    /**
+     * Constructor.
+     *
+     * @param   Http    $http     Joomla HTTP client. Same instance as the
+     *                            PC API client uses so timeouts / proxies
+     *                            stay consistent.
+     * @param   string  $cacheRoot  Absolute path to the photos directory.
+     *                              Defaults to JPATH_ROOT/media/...; tests
+     *                              point at a vfs path.
+     * @param   int     $timeoutSeconds  HTTP timeout for the download.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct(
+        private readonly Http $http,
+        private readonly string $cacheRoot,
+        private readonly int $timeoutSeconds = 30,
+    ) {}
+
+    public function cache(int $pcPersonId, ?string $avatarUrl, ?string $currentHash): ?PhotoCacheResult
+    {
+        if ($pcPersonId <= 0 || $avatarUrl === null || $avatarUrl === '') {
+            return null;
+        }
+
+        if ($this->looksLikePlaceholder($avatarUrl)) {
+            return null;
+        }
+
+        $hash = hash('sha256', $avatarUrl);
+
+        if ($currentHash !== null && hash_equals($currentHash, $hash)) {
+            // URL unchanged — assume the existing file is still good. We
+            // don't re-verify on disk; a missing file is a separate
+            // concern (admin can hit "Refresh now" to force re-download).
+            $relativePath = $this->relativePathFor($pcPersonId, $avatarUrl);
+
+            return new PhotoCacheResult($relativePath, $hash, false);
+        }
+
+        $bytes = $this->downloadBytes($avatarUrl);
+
+        if ($bytes === null) {
+            return null;
+        }
+
+        $relativePath = $this->relativePathFor($pcPersonId, $avatarUrl);
+        $this->writeBytes($relativePath, $bytes);
+
+        return new PhotoCacheResult($relativePath, $hash, true);
+    }
+
+    /**
+     * Heuristic detector for PC's generic demographic avatars. Matches the
+     * `/static/.../demographic_avatar_*.png` pattern PC currently returns.
+     *
+     * Conservative on purpose: anything we don't recognise as a placeholder
+     * gets downloaded. A false-positive (skipping a real photo) just leaves
+     * the UI placeholder visible; a false-negative (caching a placeholder)
+     * wastes a kilobyte. Erring toward "real photos win" matches Decision #13.
+     *
+     * @param   string  $url
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function looksLikePlaceholder(string $url): bool
+    {
+        $path = parse_url($url, \PHP_URL_PATH);
+
+        if (!\is_string($path) || $path === '') {
+            return false;
+        }
+
+        return str_contains($path, '/static/')
+            || str_contains($path, 'demographic_avatar')
+            || str_contains($path, 'avatar_default');
+    }
+
+    /**
+     * Build the relative path stored in `#__cwmconnect_details.image`.
+     * Extension is derived from the URL path, defaulting to `jpg` when
+     * the URL doesn't carry a clean extension.
+     *
+     * @param   int     $pcPersonId
+     * @param   string  $avatarUrl
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function relativePathFor(int $pcPersonId, string $avatarUrl): string
+    {
+        $path = parse_url($avatarUrl, \PHP_URL_PATH) ?: '';
+        $ext  = strtolower((string) (pathinfo($path, \PATHINFO_EXTENSION) ?? ''));
+
+        if (!\in_array($ext, self::SAFE_EXTENSIONS, true)) {
+            $ext = 'jpg';
+        }
+
+        return $pcPersonId . '.' . $ext;
+    }
+
+    /**
+     * Fetch the avatar bytes. Returns null on transport failure, non-2xx,
+     * over-size body, or empty body. Failures are deliberately
+     * non-exceptional so one bad URL doesn't abort a sync run.
+     *
+     * @param   string  $url
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function downloadBytes(string $url): ?string
+    {
+        try {
+            $response = $this->http->get($url, [], $this->timeoutSeconds);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $statusCode = (int) ($response->code ?? 0);
+        $body       = (string) ($response->body ?? '');
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            return null;
+        }
+
+        if ($body === '' || \strlen($body) > self::MAX_BYTES) {
+            return null;
+        }
+
+        return $body;
+    }
+
+    /**
+     * Atomically write the cached image. Creates the cache root on demand;
+     * writes to a temp file and renames so a partial download never leaves
+     * a half-written photo behind.
+     *
+     * @param   string  $relativePath
+     * @param   string  $bytes
+     *
+     * @return  void
+     *
+     * @throws  PcException  When the cache root can't be created.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function writeBytes(string $relativePath, string $bytes): void
+    {
+        if (!is_dir($this->cacheRoot) && !mkdir($this->cacheRoot, 0o755, true) && !is_dir($this->cacheRoot)) {
+            throw new PcException(\sprintf('Could not create photo cache root: %s', $this->cacheRoot));
+        }
+
+        $finalPath = rtrim($this->cacheRoot, '/') . '/' . $relativePath;
+        $tempPath  = $finalPath . '.tmp';
+
+        file_put_contents($tempPath, $bytes);
+        rename($tempPath, $finalPath);
+    }
+}

--- a/admin/src/Service/Pc/MemberRepositoryInterface.php
+++ b/admin/src/Service/Pc/MemberRepositoryInterface.php
@@ -74,4 +74,34 @@ interface MemberRepositoryInterface
      * @since   __DEPLOY_VERSION__
      */
     public function findIdByPcPersonId(int $pcPersonId): ?int;
+
+    /**
+     * Phase E: persist the cached photo's relative path + URL hash for a
+     * PC-synced member row. Called by the sync engine after
+     * {@see PhotoCacheInterface::cache()} returns a downloaded result.
+     *
+     * @param   int     $pcPersonId    PC person id (row lookup key).
+     * @param   string  $relativePath  Path under `media/com_cwmconnect/photos/`
+     *                                  to store in `image`.
+     * @param   string  $hash          SHA-256 of the source URL to store in
+     *                                  `image_hash`.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function updateImageByPcPersonId(int $pcPersonId, string $relativePath, string $hash): void;
+
+    /**
+     * Phase E: return the current `image_hash` so the engine can let
+     * {@see PhotoCacheInterface::cache()} short-circuit when the PC URL
+     * hasn't changed since last sync. Null when no hash is stored yet.
+     *
+     * @param   int  $pcPersonId
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function findImageHashByPcPersonId(int $pcPersonId): ?string;
 }

--- a/admin/src/Service/Pc/PersonMapper.php
+++ b/admin/src/Service/Pc/PersonMapper.php
@@ -98,6 +98,34 @@ final class PersonMapper
     }
 
     /**
+     * Phase E: pull the PC `avatar` URL off a person. Returns the value of
+     * the `avatar` attribute (the URL of an actually-uploaded photo), or
+     * null when the person has no avatar. We deliberately do NOT fall
+     * back to `demographic_avatar_url` here — that's PC's auto-generated
+     * initials placeholder, which the cache decides to skip downstream.
+     * Centralising the source-of-truth pick at the mapper level keeps the
+     * cache's placeholder detection a defence-in-depth check rather than
+     * the only filter.
+     *
+     * @param   array<string, mixed>  $personData
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function extractAvatarUrl(array $personData): ?string
+    {
+        $attrs  = $this->personAttributes($personData);
+        $avatar = $attrs['avatar'] ?? null;
+
+        if (!\is_string($avatar) || $avatar === '') {
+            return null;
+        }
+
+        return $avatar;
+    }
+
+    /**
      * Phase D: extract every `FieldDatum` related to a person via the
      * `field_data` relationship, paired with the PC FieldDefinition id it
      * targets. The sync engine resolves each `pc_field_id` against the

--- a/admin/src/Service/Pc/PhotoCacheInterface.php
+++ b/admin/src/Service/Pc/PhotoCacheInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Administrator\Service\Pc;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Phase E: cache a PC person's avatar locally and return the relative path
+ * plus the hash the sync engine should persist on the member row.
+ *
+ * Returns one of three outcomes:
+ *  - {@see PhotoCacheResult} when a new download landed (or the existing
+ *    file was kept because the hash already matched).
+ *  - null when there's no avatar to cache (PC returned no `avatar`, or only
+ *    a generic `demographic_avatar_url` placeholder we deliberately skip).
+ *
+ * Decision matrix (per spec §5.3 step 4):
+ *  | currentHash | avatarUrl       | expected result          |
+ *  | ----------- | --------------- | ------------------------ |
+ *  | null        | null            | null (no-op)             |
+ *  | non-null    | null            | null (keep old file)     |
+ *  | null        | new url         | Downloaded result        |
+ *  | matching    | same url        | Unchanged result         |
+ *  | mismatch    | new url         | Downloaded result        |
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface PhotoCacheInterface
+{
+    /**
+     * Ensure the local cache reflects the given PC avatar.
+     *
+     * @param   int          $pcPersonId   PC person id (filename stem).
+     * @param   string|null  $avatarUrl    PC `avatar` URL, or null when the
+     *                                      person has no real photo.
+     * @param   string|null  $currentHash  The image_hash we last stored, or
+     *                                      null if the row has no cached
+     *                                      image yet.
+     *
+     * @return  PhotoCacheResult|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function cache(int $pcPersonId, ?string $avatarUrl, ?string $currentHash): ?PhotoCacheResult;
+}

--- a/admin/src/Service/Pc/PhotoCacheResult.php
+++ b/admin/src/Service/Pc/PhotoCacheResult.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Administrator\Service\Pc;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Phase E: outcome envelope for {@see PhotoCacheInterface::cache()}.
+ *
+ * `relativePath` is the path under `media/com_cwmconnect/photos/` we want
+ * stored in `#__cwmconnect_details.image`. `hash` is the SHA-256 of the
+ * source URL — written to `image_hash` so the next sync can short-circuit
+ * when the URL hasn't changed. `downloaded` distinguishes "we just wrote
+ * bytes" from "we kept the existing file" so the SyncReport counters can
+ * separate fresh downloads from no-op hits.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class PhotoCacheResult
+{
+    public function __construct(
+        public readonly string $relativePath,
+        public readonly string $hash,
+        public readonly bool $downloaded,
+    ) {}
+}

--- a/admin/src/Service/Pc/SyncEngine.php
+++ b/admin/src/Service/Pc/SyncEngine.php
@@ -41,7 +41,15 @@ use Psr\Log\NullLogger;
  *    Joomla custom-field id (admin-managed mapping table)
  *  - {@see CustomFieldWriterInterface} performs the actual write
  *
- * Photos / household + campus FK resolution remain deferred to E / later.
+ * Phase E adds avatar caching:
+ *  - {@see PersonMapper::extractAvatarUrl()} pulls the `avatar` URL
+ *  - {@see PhotoCacheInterface} downloads + caches under
+ *    `media/com_cwmconnect/photos/{pc_person_id}.<ext>` when the URL hash
+ *    differs from the stored `image_hash`
+ *  - The new (relative path, hash) is written back via
+ *    {@see MemberRepositoryInterface::updateImageByPcPersonId()}.
+ *
+ * Household + campus FK resolution remain deferred to later phases.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -104,6 +112,7 @@ final class SyncEngine
         private readonly PersonMapper $mapper,
         private readonly ?FieldMapRepositoryInterface $fieldMapRepo = null,
         private readonly ?CustomFieldWriterInterface $fieldWriter = null,
+        private readonly ?PhotoCacheInterface $photoCache = null,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {}
 
@@ -177,6 +186,7 @@ final class SyncEngine
                     if ($pcPersonId !== null && $pcPersonId > 0) {
                         $seenIds[] = $pcPersonId;
                         $this->writeCustomFields($pcPersonId, $person, $included, $report);
+                        $this->cacheAvatar($pcPersonId, $person, $report);
                     }
                 } catch (\Throwable $e) {
                     $report->recordError($pcPersonId, $e->getMessage());
@@ -269,6 +279,62 @@ final class SyncEngine
                     $e->getMessage(),
                 ));
             }
+        }
+    }
+
+    /**
+     * Phase E: per-person avatar cache step. No-op when the engine was
+     * constructed without a photo cache (Phase C/D parity).
+     *
+     * Decision matrix lives in {@see PhotoCacheInterface::cache()}; this
+     * method just plumbs the URL + stored hash through and persists the
+     * cache's return value. Cache exceptions are captured per-person so
+     * a single bad URL doesn't abort the run.
+     *
+     * @param   int                              $pcPersonId
+     * @param   array<string, mixed>             $person
+     * @param   SyncReport                       $report
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function cacheAvatar(int $pcPersonId, array $person, SyncReport $report): void
+    {
+        if ($this->photoCache === null) {
+            return;
+        }
+
+        $avatarUrl = $this->mapper->extractAvatarUrl($person);
+
+        if ($avatarUrl === null) {
+            return;
+        }
+
+        try {
+            $currentHash = $this->repository->findImageHashByPcPersonId($pcPersonId);
+            $result      = $this->photoCache->cache($pcPersonId, $avatarUrl, $currentHash);
+
+            if ($result === null) {
+                return;
+            }
+
+            if ($result->downloaded) {
+                $this->repository->updateImageByPcPersonId(
+                    $pcPersonId,
+                    $result->relativePath,
+                    $result->hash,
+                );
+                $report->photosDownloaded++;
+            } else {
+                $report->photosUnchanged++;
+            }
+        } catch (\Throwable $e) {
+            $report->recordError($pcPersonId, 'Photo cache failed: ' . $e->getMessage());
+            $this->logger->error('PC sync photo cache error.', [
+                'pcPersonId' => $pcPersonId,
+                'error'      => $e->getMessage(),
+            ]);
         }
     }
 

--- a/admin/src/Service/Pc/SyncReport.php
+++ b/admin/src/Service/Pc/SyncReport.php
@@ -81,6 +81,25 @@ final class SyncReport
     public int $customFieldsWritten = 0;
 
     /**
+     * Phase E: avatars actually downloaded this run (URL hash differed
+     * from the stored value, or no hash was stored yet).
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    public int $photosDownloaded = 0;
+
+    /**
+     * Phase E: avatars whose URL hash matched the stored value, so the
+     * existing cache file was kept. Tracked separately so the run
+     * summary distinguishes "we saved bandwidth" from "we wrote bytes."
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    public int $photosUnchanged = 0;
+
+    /**
      * Per-person error list, one entry per failure.
      *
      * @var    list<array{pcPersonId: int|null, message: string}>
@@ -201,6 +220,8 @@ final class SyncReport
             'archived'         => $this->archived,
             'unarchived'       => $this->unarchived,
             'customFieldsWritten' => $this->customFieldsWritten,
+            'photosDownloaded'    => $this->photosDownloaded,
+            'photosUnchanged'     => $this->photosUnchanged,
             'errorCount'       => $this->errorCount(),
             'errors'           => $this->errors,
             'startedAt'        => $this->startedAt->format(\DateTimeImmutable::ATOM),

--- a/tests/unit/Service/Pc/MediaPhotoCacheTest.php
+++ b/tests/unit/Service/Pc/MediaPhotoCacheTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Service\Pc;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\MediaPhotoCache;
+use Joomla\CMS\Http\Http;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase E coverage for the photo cache decision matrix + filesystem
+ * effects.
+ */
+#[CoversClass(MediaPhotoCache::class)]
+final class MediaPhotoCacheTest extends TestCase
+{
+    private string $cacheRoot;
+
+    protected function setUp(): void
+    {
+        $this->cacheRoot = sys_get_temp_dir() . '/cwmconnect-phototest-' . bin2hex(random_bytes(8));
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->cacheRoot)) {
+            foreach (glob($this->cacheRoot . '/*') ?: [] as $file) {
+                @unlink($file);
+            }
+            @rmdir($this->cacheRoot);
+        }
+    }
+
+    #[Test]
+    public function returnsNullWhenAvatarUrlIsNull(): void
+    {
+        $cache = $this->cacheWithBytes('anything');
+
+        self::assertNull($cache->cache(42, null, null));
+    }
+
+    #[Test]
+    public function returnsNullForDemographicPlaceholder(): void
+    {
+        $http  = $this->countingHttp('IRRELEVANT');
+        $cache = new MediaPhotoCache($http, $this->cacheRoot);
+
+        $out = $cache->cache(
+            42,
+            'https://avatars.planningcenteronline.com/static/demographic_avatar_blue.png',
+            null,
+        );
+
+        self::assertNull($out);
+        self::assertSame(0, $http->calls, 'Placeholder must never trigger a download.');
+    }
+
+    #[Test]
+    public function downloadsAndWritesFileOnFirstSync(): void
+    {
+        $bytes = 'JFIF...fake jpg bytes...';
+        $cache = $this->cacheWithBytes($bytes);
+        $url   = 'https://avatars.planningcenteronline.com/uploads/abc.jpg';
+
+        $result = $cache->cache(42, $url, null);
+
+        self::assertNotNull($result);
+        self::assertSame('42.jpg', $result->relativePath);
+        self::assertSame(hash('sha256', $url), $result->hash);
+        self::assertTrue($result->downloaded);
+        self::assertSame($bytes, file_get_contents($this->cacheRoot . '/42.jpg'));
+    }
+
+    #[Test]
+    public function returnsUnchangedResultWhenHashMatches(): void
+    {
+        $url   = 'https://avatars.planningcenteronline.com/uploads/abc.png';
+        $hash  = hash('sha256', $url);
+        $http  = $this->countingHttp('NEW_BYTES');
+        $cache = new MediaPhotoCache($http, $this->cacheRoot);
+
+        $result = $cache->cache(7, $url, $hash);
+
+        self::assertNotNull($result);
+        self::assertFalse($result->downloaded);
+        self::assertSame($hash, $result->hash);
+        self::assertSame(0, $http->calls, 'Matching hash must short-circuit the HTTP call.');
+    }
+
+    #[Test]
+    public function downloadsAgainWhenUrlChanges(): void
+    {
+        $oldUrl = 'https://avatars.planningcenteronline.com/uploads/v1.png';
+        $newUrl = 'https://avatars.planningcenteronline.com/uploads/v2.png';
+        $cache  = $this->cacheWithBytes('NEW');
+
+        $result = $cache->cache(7, $newUrl, hash('sha256', $oldUrl));
+
+        self::assertNotNull($result);
+        self::assertTrue($result->downloaded);
+        self::assertSame(hash('sha256', $newUrl), $result->hash);
+    }
+
+    #[Test]
+    public function returnsNullWhenHttpReturnsNon2xx(): void
+    {
+        $http  = $this->httpReturning(500, 'server error');
+        $cache = new MediaPhotoCache($http, $this->cacheRoot);
+
+        self::assertNull(
+            $cache->cache(7, 'https://avatars.planningcenteronline.com/uploads/abc.png', null),
+        );
+    }
+
+    #[Test]
+    public function rejectsResponsesLargerThan5MB(): void
+    {
+        $http  = $this->httpReturning(200, str_repeat('x', 5 * 1024 * 1024 + 1));
+        $cache = new MediaPhotoCache($http, $this->cacheRoot);
+
+        self::assertNull(
+            $cache->cache(7, 'https://avatars.planningcenteronline.com/uploads/abc.png', null),
+        );
+    }
+
+    #[Test]
+    public function fallsBackToJpgWhenUrlHasNoSafeExtension(): void
+    {
+        $cache  = $this->cacheWithBytes('bytes');
+        $result = $cache->cache(
+            9,
+            'https://avatars.planningcenteronline.com/photo?token=abc',
+            null,
+        );
+
+        self::assertNotNull($result);
+        self::assertSame('9.jpg', $result->relativePath);
+    }
+
+    private function cacheWithBytes(string $bytes): MediaPhotoCache
+    {
+        return new MediaPhotoCache($this->httpReturning(200, $bytes), $this->cacheRoot);
+    }
+
+    private function httpReturning(int $code, string $body): Http
+    {
+        return new class ($code, $body) extends Http {
+            public int $calls = 0;
+
+            public function __construct(public readonly int $code, public readonly string $body) {}
+
+            public function get(string $url, array $headers = [], ?int $timeout = null): mixed
+            {
+                $this->calls++;
+
+                return new class ($this->code, $this->body) {
+                    public function __construct(public readonly int $code, public readonly string $body) {}
+                };
+            }
+        };
+    }
+
+    /**
+     * Same as httpReturning but exposes a counter so a test can assert
+     * the HTTP layer was (or wasn't) called.
+     */
+    private function countingHttp(string $body): Http
+    {
+        return $this->httpReturning(200, $body);
+    }
+}

--- a/tests/unit/Service/Pc/PersonMapperAvatarTest.php
+++ b/tests/unit/Service/Pc/PersonMapperAvatarTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Service\Pc;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\PersonMapper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase E coverage for {@see PersonMapper::extractAvatarUrl()}.
+ */
+#[CoversClass(PersonMapper::class)]
+final class PersonMapperAvatarTest extends TestCase
+{
+    #[Test]
+    public function returnsAvatarAttributeWhenSet(): void
+    {
+        $url = 'https://avatars.planningcenteronline.com/uploads/abc.png';
+        $out = new PersonMapper()->extractAvatarUrl([
+            'attributes' => ['avatar' => $url],
+        ]);
+
+        self::assertSame($url, $out);
+    }
+
+    #[Test]
+    public function returnsNullWhenAvatarMissing(): void
+    {
+        self::assertNull(new PersonMapper()->extractAvatarUrl(['attributes' => []]));
+    }
+
+    #[Test]
+    public function returnsNullWhenAvatarEmptyString(): void
+    {
+        self::assertNull(
+            new PersonMapper()->extractAvatarUrl(['attributes' => ['avatar' => '']]),
+        );
+    }
+
+    #[Test]
+    public function doesNotFallBackToDemographicAvatarUrl(): void
+    {
+        // Decision: `demographic_avatar_url` is PC's generic placeholder;
+        // we never treat it as a real photo. The cache layer also detects
+        // placeholders defensively, but the mapper is the first filter.
+        $out = new PersonMapper()->extractAvatarUrl([
+            'attributes' => [
+                'avatar'                 => null,
+                'demographic_avatar_url' => 'https://avatars.planningcenteronline.com/static/demographic_avatar_42.png',
+            ],
+        ]);
+
+        self::assertNull($out);
+    }
+}

--- a/tests/unit/Service/Pc/SyncEnginePhaseDTest.php
+++ b/tests/unit/Service/Pc/SyncEnginePhaseDTest.php
@@ -126,6 +126,16 @@ final class SyncEnginePhaseDTest extends TestCase
             {
                 return 1000 + $pcPersonId;
             }
+
+            public function updateImageByPcPersonId(int $pcPersonId, string $relativePath, string $hash): void
+            {
+                // Phase D tests don't wire a photo cache; this is unreachable.
+            }
+
+            public function findImageHashByPcPersonId(int $pcPersonId): ?string
+            {
+                return null;
+            }
         };
     }
 

--- a/tests/unit/Service/Pc/SyncEnginePhaseETest.php
+++ b/tests/unit/Service/Pc/SyncEnginePhaseETest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Service\Pc;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\Client;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\MemberRepositoryInterface;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\PersonMapper;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\PhotoCacheInterface;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\PhotoCacheResult;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\SyncEngine;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\UpsertOutcome;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase E: SyncEngine ↔ PhotoCache wiring + report counters.
+ */
+#[CoversClass(SyncEngine::class)]
+final class SyncEnginePhaseETest extends TestCase
+{
+    #[Test]
+    public function downloadedResultIncrementsCounterAndPersistsImage(): void
+    {
+        $client = $this->clientReturning($this->pageWith([$this->personWithAvatar(1, 'https://x/abc.png')]));
+        $repo   = $this->trackingRepo();
+        $cache  = $this->stubCache(new PhotoCacheResult('1.png', 'hash1', true));
+
+        $report = new SyncEngine($client, $repo, new PersonMapper(), null, null, $cache)->run([]);
+
+        self::assertSame(1, $report->photosDownloaded);
+        self::assertSame(0, $report->photosUnchanged);
+        self::assertSame(
+            [['pcPersonId' => 1, 'relativePath' => '1.png', 'hash' => 'hash1']],
+            $repo->imageWrites,
+        );
+    }
+
+    #[Test]
+    public function unchangedResultIncrementsCounterAndSkipsPersistence(): void
+    {
+        $client = $this->clientReturning($this->pageWith([$this->personWithAvatar(1, 'https://x/abc.png')]));
+        $repo   = $this->trackingRepo();
+        $cache  = $this->stubCache(new PhotoCacheResult('1.png', 'hash1', false));
+
+        $report = new SyncEngine($client, $repo, new PersonMapper(), null, null, $cache)->run([]);
+
+        self::assertSame(0, $report->photosDownloaded);
+        self::assertSame(1, $report->photosUnchanged);
+        self::assertSame([], $repo->imageWrites);
+    }
+
+    #[Test]
+    public function nullCacheResultLeavesAllCountersAtZero(): void
+    {
+        $client = $this->clientReturning($this->pageWith([$this->personWithAvatar(1, 'https://x/abc.png')]));
+        $repo   = $this->trackingRepo();
+        $cache  = $this->stubCache(null);
+
+        $report = new SyncEngine($client, $repo, new PersonMapper(), null, null, $cache)->run([]);
+
+        self::assertSame(0, $report->photosDownloaded);
+        self::assertSame(0, $report->photosUnchanged);
+        self::assertSame([], $repo->imageWrites);
+    }
+
+    #[Test]
+    public function personWithoutAvatarSkipsCacheEntirely(): void
+    {
+        $client = $this->clientReturning($this->pageWith([$this->personWithAvatar(1, null)]));
+        $repo   = $this->trackingRepo();
+        $cache  = $this->countingCache();
+
+        new SyncEngine($client, $repo, new PersonMapper(), null, null, $cache)->run([]);
+
+        self::assertSame(0, $cache->calls, 'No avatar URL must never reach the cache.');
+    }
+
+    #[Test]
+    public function photoStepIsSkippedWhenNoCacheIsWired(): void
+    {
+        $client = $this->clientReturning($this->pageWith([$this->personWithAvatar(1, 'https://x/abc.png')]));
+        $repo   = $this->trackingRepo();
+
+        // No cache passed — Phase C/D parity.
+        $report = new SyncEngine($client, $repo, new PersonMapper())->run([]);
+
+        self::assertSame(0, $report->photosDownloaded);
+        self::assertSame([], $repo->imageWrites);
+        self::assertTrue($report->success());
+    }
+
+    #[Test]
+    public function cacheExceptionIsRecordedAndDoesNotAbortRun(): void
+    {
+        $client = $this->clientReturning($this->pageWith([$this->personWithAvatar(1, 'https://x/abc.png')]));
+        $repo   = $this->trackingRepo();
+        $cache  = new class implements PhotoCacheInterface {
+            public function cache(int $pcPersonId, ?string $avatarUrl, ?string $currentHash): ?PhotoCacheResult
+            {
+                throw new \RuntimeException('disk full');
+            }
+        };
+
+        $report = new SyncEngine($client, $repo, new PersonMapper(), null, null, $cache)->run([]);
+
+        self::assertSame(0, $report->photosDownloaded);
+        self::assertSame(1, $report->errorCount());
+        self::assertFalse($report->success());
+    }
+
+    private function clientReturning(array $page): Client
+    {
+        return new class ($page) extends Client {
+            public function __construct(private array $page) {}
+
+            public function getJson(string $path, array $query = []): array
+            {
+                return $this->page;
+            }
+
+            public function getJsonAbsolute(string $url): array
+            {
+                return ['data' => [], 'included' => [], 'links' => []];
+            }
+        };
+    }
+
+    private function trackingRepo(): MemberRepositoryInterface
+    {
+        return new class implements MemberRepositoryInterface {
+            /** @var list<array{pcPersonId: int, relativePath: string, hash: string}> */
+            public array $imageWrites = [];
+
+            public function upsertByPcPersonId(array $attrs): UpsertOutcome
+            {
+                return UpsertOutcome::Added;
+            }
+
+            public function archiveMissingPcPersonIds(array $seenPcPersonIds): int
+            {
+                return 0;
+            }
+
+            public function findIdByPcPersonId(int $pcPersonId): ?int
+            {
+                return 1000 + $pcPersonId;
+            }
+
+            public function updateImageByPcPersonId(int $pcPersonId, string $relativePath, string $hash): void
+            {
+                $this->imageWrites[] = [
+                    'pcPersonId'   => $pcPersonId,
+                    'relativePath' => $relativePath,
+                    'hash'         => $hash,
+                ];
+            }
+
+            public function findImageHashByPcPersonId(int $pcPersonId): ?string
+            {
+                return null;
+            }
+        };
+    }
+
+    private function stubCache(?PhotoCacheResult $result): PhotoCacheInterface
+    {
+        return new class ($result) implements PhotoCacheInterface {
+            public function __construct(private readonly ?PhotoCacheResult $result) {}
+
+            public function cache(int $pcPersonId, ?string $avatarUrl, ?string $currentHash): ?PhotoCacheResult
+            {
+                return $this->result;
+            }
+        };
+    }
+
+    /** @return object&PhotoCacheInterface */
+    private function countingCache(): object
+    {
+        return new class implements PhotoCacheInterface {
+            public int $calls = 0;
+
+            public function cache(int $pcPersonId, ?string $avatarUrl, ?string $currentHash): ?PhotoCacheResult
+            {
+                $this->calls++;
+
+                return null;
+            }
+        };
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $data
+     *
+     * @return array<string, mixed>
+     */
+    private function pageWith(array $data): array
+    {
+        return ['data' => $data, 'included' => [], 'links' => []];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function personWithAvatar(int $personId, ?string $avatarUrl): array
+    {
+        return [
+            'type'          => 'Person',
+            'id'            => (string) $personId,
+            'attributes'    => [
+                'first_name' => 'Alice',
+                'last_name'  => 'Test',
+                'avatar'     => $avatarUrl,
+            ],
+            'relationships' => [],
+        ];
+    }
+}

--- a/tests/unit/Service/Pc/SyncEngineTest.php
+++ b/tests/unit/Service/Pc/SyncEngineTest.php
@@ -274,6 +274,17 @@ final class SyncEngineTest extends TestCase
                 // which the Phase C-style tests never request.
                 return 1000 + $pcPersonId;
             }
+
+            public function updateImageByPcPersonId(int $pcPersonId, string $relativePath, string $hash): void
+            {
+                // No-op stub — Phase C-style tests run without a photo cache,
+                // so the engine never calls this method on them.
+            }
+
+            public function findImageHashByPcPersonId(int $pcPersonId): ?string
+            {
+                return null;
+            }
         };
     }
 


### PR DESCRIPTION
## Summary
- `PhotoCacheInterface` + production `MediaPhotoCache` cache PC avatars under `media/com_cwmconnect/photos/{pc_person_id}.<ext>`. Hash strategy: SHA-256 of the source URL — PC bakes the version into the URL so two different URLs guarantee two different photos, no need to fetch bytes to diff. Per spec Decision #13 + §5.3 step 4.
- `MediaPhotoCache` defends against runaway downloads (5MB cap), unsafe extensions (allow-list with `.jpg` fallback), and PC's generic `demographic_avatar_url` placeholder (path heuristic).
- `PersonMapper::extractAvatarUrl()` returns the `avatar` attribute only — never falls back to `demographic_avatar_url`. The cache's placeholder check is a defence-in-depth layer.
- `MemberRepositoryInterface` grows `updateImageByPcPersonId()` + `findImageHashByPcPersonId()` so the engine can read the stored hash before asking the cache to decide, and write the cached path/hash back afterward.
- `SyncEngine` constructor takes a nullable `PhotoCacheInterface` (Phase C/D parity). Per-person `cacheAvatar()` runs after the custom-field write step; failures are captured per spec §5.5.
- `SyncReport` gains `photosDownloaded` + `photosUnchanged` counters.
- DI wires `MediaPhotoCache` against `JPATH_ROOT/media/com_cwmconnect/photos`.
- `.gitignore` excludes the photos cache (runtime artifacts).

## Design notes
- Atomic write: download → temp file → `rename()`. A torn download never leaves a half-written photo behind.
- Cache root is created lazily on first write (`mkdir -p`) so a fresh install doesn't need a manual bootstrap step.
- Hash short-circuit: when `image_hash` matches the SHA-256 of the new URL, we return an `Unchanged` result with `downloaded=false` and don't touch the DB or the disk. Counter still increments so the sync summary shows the work was considered.
- HTTP errors / oversize bodies return `null` rather than throwing — one bad avatar URL never aborts a sync run.
- `FieldsHelperWriter` and `MediaPhotoCache` together mean Phase C/D/E all flow through the same per-person try/catch in the engine.

## Test plan
- [x] `composer check` — **76 / 76 tests pass** (18 new across `MediaPhotoCacheTest`, `PersonMapperAvatarTest`, `SyncEnginePhaseETest`), lint clean, syntax clean.
- [ ] Manual: install/update on a J5 site, point at a PC org with at least one person who has a real avatar AND one with only the demographic placeholder. Run **Sync now**, confirm `photosDownloaded` > 0, `photosUnchanged` == 0 on first sync, and that placeholder people produce no file under `media/com_cwmconnect/photos/`.
- [ ] Manual: re-run sync — `photosDownloaded` should drop to 0, `photosUnchanged` should match the photo count.

## Deferred
- Cpanel "Refresh photos" button (spec §5.2 mentions it). Lands as a follow-up PR — adds a controller route that forces a sync with `force=1` to ignore stored hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)