### PR TITLE
Phase F: admin form lock for PC-linked members

### DIFF
--- a/admin/language/en-GB/com_cwmconnect.ini
+++ b/admin/language/en-GB/com_cwmconnect.ini
@@ -1109,3 +1109,8 @@ COM_CWMCONNECT_PC_FIELD_MAP_ERR_NO_PC_FIELD="A Planning Center field id is requi
 COM_CWMCONNECT_PC_FIELD_MAP_ERR_NO_JOOMLA_FIELD="A Joomla custom field must be selected."
 COM_CWMCONNECT_PC_FIELD_MAP_ERR_PC_FIELD_TAKEN="This Planning Center field is already mapped to a different Joomla field. Edit or delete that mapping first."
 COM_CWMCONNECT_PC_FIELD_MAP_ERR_JOOMLA_FIELD_TAKEN="This Joomla custom field is already the target of a different mapping. Edit or delete that mapping first."
+
+; Phase F — admin form lock (PC-linked members)
+COM_CWMCONNECT_PC_LOCK_BANNER_TITLE="Synced from Planning Center."
+COM_CWMCONNECT_PC_LOCK_BANNER_BODY=" PC person #%1$d. Last synced %2$s. Identity, contact, address, dates, and the cached photo are read-only here — edit them in Planning Center."
+COM_CWMCONNECT_PC_LOCK_BANNER_VIEW_IN_PC="View in Planning Center"

--- a/admin/src/Helper/PcLockedFields.php
+++ b/admin/src/Helper/PcLockedFields.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Administrator\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Phase F: which fields on the admin Member edit form should render
+ * read-only because they're owned by Planning Center.
+ *
+ * Pure helper — no DB, no Joomla state. Caller passes an `stdClass`
+ * (or anything `\stdClass`-shaped) representing the loaded member row;
+ * we return the local-column names to lock.
+ *
+ * **Local columns only.** Locking PC-mapped *custom* fields lives in the
+ * model where the Joomla `#__fields` table is already in scope — see
+ * {@see \CWM\Component\Cwmconnect\Administrator\Service\Pc\FieldMapRepositoryInterface::lockedJoomlaFieldNames()}.
+ *
+ * Lock policy (per spec §6.3):
+ *  - Identity / contact / address / dates → locked when `pc_person_id` is set
+ *  - `image` → locked when `pc_person_id` is set (Phase E owns the avatar
+ *    cache; a future Phase H photo override would bypass this lock through
+ *    a different column)
+ *  - `display_in_directory` → locked only when PC set it to 0 (child or
+ *    `directory_status=no`). Admin can edit when PC left it visible.
+ *
+ * `alias`, `con_position`, `featured`, and Joomla metadata (`catid`,
+ * `ordering`, `language`, ...) stay editable so admins keep control over
+ * directory-local concerns.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class PcLockedFields
+{
+    /**
+     * Always-locked local columns when the row is PC-linked.
+     *
+     * @var    list<string>
+     * @since  __DEPLOY_VERSION__
+     */
+    private const BASE_LOCKED = [
+        'name',
+        'surname',
+        'lname',
+        'email_to',
+        'telephone',
+        'mobile',
+        'address',
+        'suburb',
+        'state',
+        'postcode',
+        'country',
+        'birthdate',
+        'anniversary',
+        'image',
+    ];
+
+    /**
+     * Compute the locked-column set for a given item.
+     *
+     * @param   object|null  $item  Loaded member row. Pass `null` when the
+     *                               form is rendered for a brand-new record
+     *                               (id=0); nothing is ever locked there.
+     *
+     * @return  list<string>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function forItem(?object $item): array
+    {
+        if ($item === null) {
+            return [];
+        }
+
+        $pcPersonId = (int) ($item->pc_person_id ?? 0);
+
+        if ($pcPersonId <= 0) {
+            return [];
+        }
+
+        $locked = self::BASE_LOCKED;
+
+        // PC set this row's visibility to 0 (either via the child boolean
+        // or directory_status=no). Admin can't accidentally re-enable
+        // visibility without unlinking the row first.
+        if ((int) ($item->display_in_directory ?? 1) === 0) {
+            $locked[] = 'display_in_directory';
+        }
+
+        return $locked;
+    }
+}

--- a/admin/src/Model/MemberModel.php
+++ b/admin/src/Model/MemberModel.php
@@ -15,6 +15,8 @@ namespace CWM\Component\Cwmconnect\Administrator\Model;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Cwmconnect\Administrator\Helper\PcLockedFields;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\FieldMapRepositoryInterface;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Categories\CategoriesHelper;
 use Joomla\CMS\Factory;
@@ -487,7 +489,62 @@ class MemberModel extends AdminModel
             $form->setFieldAttribute('published', 'filter', 'unset');
         }
 
+        $this->applyPcFieldLocks($form);
+
         return $form;
+    }
+
+    /**
+     * Phase F: render PC-owned fields as read-only and `filter=unset` so
+     * the model never accepts a value for them from the admin form. The
+     * lock covers two surfaces:
+     *
+     *  - Local columns (name, contact, address, dates, image) via
+     *    {@see PcLockedFields::forItem()}.
+     *  - Joomla custom fields whose ids appear in the PC mapping table,
+     *    via {@see FieldMapRepositoryInterface::lockedJoomlaFieldNames()}.
+     *
+     * No-op for new records (id=0) and standalone members (no
+     * `pc_person_id`). `filter=unset` is the load-bearing part: even if a
+     * malicious POST bypasses the disabled UI, the model drops the value
+     * before save.
+     *
+     * @param   Form  $form
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function applyPcFieldLocks(Form $form): void
+    {
+        $item = $this->getItem((int) $this->getState($this->getName() . '.id', 0));
+
+        if (!\is_object($item) || (int) ($item->pc_person_id ?? 0) <= 0) {
+            return;
+        }
+
+        foreach (PcLockedFields::forItem($item) as $fieldName) {
+            $form->setFieldAttribute($fieldName, 'readonly', 'true');
+            $form->setFieldAttribute($fieldName, 'disabled', 'true');
+            $form->setFieldAttribute($fieldName, 'filter', 'unset');
+        }
+
+        try {
+            $repo = Factory::getContainer()->get(FieldMapRepositoryInterface::class);
+        } catch (\Throwable) {
+            // DI container unreachable in unusual contexts (e.g. CLI
+            // form discovery). Local-column lock above is already in
+            // place; we just skip the custom-field layer.
+            return;
+        }
+
+        foreach ($repo->lockedJoomlaFieldNames() as $fieldName) {
+            // com_fields adds custom fields under the `com_fields` form
+            // path; the fourth setFieldAttribute() arg targets that path.
+            $form->setFieldAttribute($fieldName, 'readonly', 'true', 'com_fields');
+            $form->setFieldAttribute($fieldName, 'disabled', 'true', 'com_fields');
+            $form->setFieldAttribute($fieldName, 'filter', 'unset', 'com_fields');
+        }
     }
 
     /**

--- a/admin/src/Service/Pc/DatabaseFieldMapRepository.php
+++ b/admin/src/Service/Pc/DatabaseFieldMapRepository.php
@@ -63,4 +63,24 @@ final class DatabaseFieldMapRepository implements FieldMapRepositoryInterface
 
         return $out;
     }
+
+    public function lockedJoomlaFieldNames(): array
+    {
+        $query = $this->db->getQuery(true)
+            ->select($this->db->quoteName('f.name'))
+            ->from($this->db->quoteName(self::TABLE, 'm'))
+            ->join(
+                'INNER',
+                $this->db->quoteName('#__fields', 'f') . ' ON '
+                    . $this->db->quoteName('f.id') . ' = ' . $this->db->quoteName('m.joomla_field_id'),
+            )
+            ->where($this->db->quoteName('f.state') . ' = 1');
+
+        $names = $this->db->setQuery($query)->loadColumn() ?: [];
+
+        return array_values(array_filter(
+            array_map('strval', $names),
+            static fn(string $name): bool => $name !== '',
+        ));
+    }
 }

--- a/admin/src/Service/Pc/FieldMapRepositoryInterface.php
+++ b/admin/src/Service/Pc/FieldMapRepositoryInterface.php
@@ -41,4 +41,22 @@ interface FieldMapRepositoryInterface
      * @since   __DEPLOY_VERSION__
      */
     public function allKeyedByPcFieldId(): array;
+
+    /**
+     * Phase F: list the Joomla custom-field NAMES (column from
+     * `#__fields.name`, not `title`) that should render read-only on
+     * any `com_cwmconnect.member` form because their value is owned
+     * by Planning Center.
+     *
+     * Returned as names (not ids) because `Form::setFieldAttribute()`
+     * keys off the field's name. Custom-field rows whose
+     * `joomla_field_id` no longer resolves to an existing `#__fields`
+     * row are silently skipped — the mapping list view already
+     * surfaces the broken pairing.
+     *
+     * @return  list<string>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function lockedJoomlaFieldNames(): array;
 }

--- a/admin/tmpl/member/edit.php
+++ b/admin/tmpl/member/edit.php
@@ -52,9 +52,34 @@ $this->getDocument()->addScriptDeclaration(<<<JS
 
 // Fieldsets that are rendered manually below.
 $this->ignore_fieldsets = ['details', 'item_associations', 'jmetadata'];
+
+// Phase F: "Synced from PC" banner data. Locks themselves are applied in MemberModel.
+$pcPersonId   = (int) ($this->item->pc_person_id ?? 0);
+$pcLastSynced = (string) ($this->item->pc_last_synced_at ?? '');
+$pcProfileUrl = $pcPersonId > 0
+    ? 'https://people.planningcenteronline.com/people/' . $pcPersonId
+    : '';
 ?>
 <form action="<?php echo Route::_('index.php?option=com_cwmconnect&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>"
       method="post" name="adminForm" id="member-form" class="form-validate">
+
+    <?php if ($pcPersonId > 0) : ?>
+        <div class="alert alert-info d-flex align-items-center" role="status">
+            <span class="icon-link me-2" aria-hidden="true"></span>
+            <div class="flex-grow-1">
+                <strong><?php echo Text::_('COM_CWMCONNECT_PC_LOCK_BANNER_TITLE'); ?></strong>
+                <?php echo Text::sprintf(
+                    'COM_CWMCONNECT_PC_LOCK_BANNER_BODY',
+                    $pcPersonId,
+                    $this->escape($pcLastSynced !== '' ? $pcLastSynced : Text::_('JNEVER')),
+                ); ?>
+            </div>
+            <a class="btn btn-sm btn-outline-secondary" href="<?php echo $this->escape($pcProfileUrl); ?>" target="_blank" rel="noopener noreferrer">
+                <?php echo Text::_('COM_CWMCONNECT_PC_LOCK_BANNER_VIEW_IN_PC'); ?>
+                <span class="icon-out-2" aria-hidden="true"></span>
+            </a>
+        </div>
+    <?php endif; ?>
 
     <?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 

--- a/tests/unit/Helper/PcLockedFieldsTest.php
+++ b/tests/unit/Helper/PcLockedFieldsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Helper;
+
+use CWM\Component\Cwmconnect\Administrator\Helper\PcLockedFields;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase F coverage for the locked-fields decision matrix.
+ */
+#[CoversClass(PcLockedFields::class)]
+final class PcLockedFieldsTest extends TestCase
+{
+    #[Test]
+    public function returnsEmptyListForNullItem(): void
+    {
+        self::assertSame([], PcLockedFields::forItem(null));
+    }
+
+    #[Test]
+    public function returnsEmptyListForStandaloneMember(): void
+    {
+        $item = (object) ['pc_person_id' => null, 'display_in_directory' => 1];
+
+        self::assertSame([], PcLockedFields::forItem($item));
+    }
+
+    #[Test]
+    public function returnsEmptyListForPcPersonIdZero(): void
+    {
+        $item = (object) ['pc_person_id' => 0];
+
+        self::assertSame([], PcLockedFields::forItem($item));
+    }
+
+    #[Test]
+    public function locksBaseSetForPcLinkedMemberStillVisible(): void
+    {
+        $item   = (object) ['pc_person_id' => 42, 'display_in_directory' => 1];
+        $locked = PcLockedFields::forItem($item);
+
+        foreach (['name', 'email_to', 'telephone', 'address', 'birthdate', 'image'] as $expected) {
+            self::assertContains(
+                $expected,
+                $locked,
+                \sprintf('Expected `%s` to be locked for a PC-linked member.', $expected),
+            );
+        }
+
+        self::assertNotContains(
+            'display_in_directory',
+            $locked,
+            'display_in_directory must stay editable when PC has it visible.',
+        );
+        self::assertNotContains('alias', $locked, 'Alias is editable per spec §6.3.');
+        self::assertNotContains('con_position', $locked, 'Position is editable per spec §6.3.');
+    }
+
+    #[Test]
+    public function locksDisplayInDirectoryWhenPcHidesTheRow(): void
+    {
+        // PC's child boolean (or directory_status=no) set the flag to 0.
+        // Admin must unlink the row before re-enabling visibility.
+        $item   = (object) ['pc_person_id' => 42, 'display_in_directory' => 0];
+        $locked = PcLockedFields::forItem($item);
+
+        self::assertContains('display_in_directory', $locked);
+    }
+
+    #[Test]
+    public function treatsStringIdsAsIntegers(): void
+    {
+        // pc_person_id arrives as a string from the DB driver in some cases.
+        $item = (object) ['pc_person_id' => '7', 'display_in_directory' => 1];
+
+        self::assertNotEmpty(PcLockedFields::forItem($item));
+    }
+}

--- a/tests/unit/Service/Pc/SyncEnginePhaseDTest.php
+++ b/tests/unit/Service/Pc/SyncEnginePhaseDTest.php
@@ -152,6 +152,13 @@ final class SyncEnginePhaseDTest extends TestCase
             {
                 return $this->rows;
             }
+
+            public function lockedJoomlaFieldNames(): array
+            {
+                // Phase D tests don't exercise the form-lock path; return
+                // an empty list so the engine never tries to apply a lock.
+                return [];
+            }
         };
     }
 


### PR DESCRIPTION
## Summary
- New `PcLockedFields` helper (pure, testable) returns the local-column lock set for a member row: identity, contact, address, dates, and image when `pc_person_id` is set; plus `display_in_directory` when PC has it at 0 (child-row protection per spec §7.1).
- New `FieldMapRepositoryInterface::lockedJoomlaFieldNames()` joins `#__cwmconnect_pc_field_map` to `#__fields` and returns the names of mapped, published custom fields — those get locked via `setFieldAttribute(..., 'com_fields')` so com_fields-injected fields participate in the lock.
- `MemberModel::getForm()` applies both lock layers with `readonly="true"`, `disabled="true"`, **and `filter="unset"`** so a hand-crafted POST can never sneak a value past the model.
- `admin/tmpl/member/edit.php` renders a "Synced from Planning Center" info banner above the form when `pc_person_id` is set: PC person id, last-sync timestamp, and a "View in Planning Center" link.
- New language strings (3) for the banner.

## Design notes
- The `filter="unset"` part is the load-bearing lock. `readonly`/`disabled` are UX; the filter is the security boundary. Both halves matter.
- DI lookup in the model is wrapped in `try { ... } catch (\Throwable)` so unusual contexts (CLI form discovery, etc.) that don't have the container wired still get the local-column lock — they just skip the custom-field layer.
- Custom-field lock uses `$form->setFieldAttribute($name, ..., 'com_fields')` — the fourth arg targets com_fields' form path so injected custom-fields participate.
- `alias`, `con_position`, `featured`, `catid`, `display_in_directory` (when PC has it visible) stay editable per spec §6.3.

## Test plan
- [x] `composer check` — **82 / 82 tests pass** (6 new in `PcLockedFieldsTest`), lint clean.
- [ ] Manual: open a PC-synced member in admin → confirm banner renders, locked fields show as disabled, "View in Planning Center" link opens the right URL.
- [ ] Manual: open a standalone (non-PC) member → confirm no banner, all fields editable.
- [ ] Manual: open a PC-linked child row (display_in_directory=0) → confirm the visibility toggle is also disabled.
- [ ] Manual: with a Phase D mapping saved against a Joomla custom field on `com_cwmconnect.member`, open a PC-linked member → confirm that custom field renders read-only.
- [ ] Security: hand-craft a POST with values for locked fields → confirm the model drops them (no DB change).

## Deferred
- `[⚓ Synced from PC ▾]` dropdown with Sync-now / Unlink-from-PC actions (spec §6.3 mock). Needs new controller routes + JS confirms — clean follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)