### PR TITLE
Phase H.2: identity-binding pair automation (PC sync + user plugin)

### DIFF
--- a/admin/services/provider.php
+++ b/admin/services/provider.php
@@ -10,6 +10,8 @@
 \defined('_JEXEC') or die;
 
 use CWM\Component\Cwmconnect\Administrator\Extension\CwmconnectComponent;
+use CWM\Component\Cwmconnect\Administrator\Service\Pairing\DatabaseMemberPairing;
+use CWM\Component\Cwmconnect\Administrator\Service\Pairing\MemberPairingInterface;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\Client as PcClient;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\CustomFieldWriterInterface as PcCustomFieldWriterInterface;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\DatabaseFieldMapRepository as PcDatabaseFieldMapRepository;
@@ -126,6 +128,13 @@ return new class implements ServiceProviderInterface {
             ),
         );
 
+        // Phase H: identity-binding pair service shared with plg_user_cwmconnect.
+        $container->set(
+            MemberPairingInterface::class,
+            static fn(Container $c): MemberPairingInterface
+                => new DatabaseMemberPairing($c->get(DatabaseInterface::class)),
+        );
+
         $container->set(
             PcSyncEngine::class,
             static fn(Container $c): PcSyncEngine => new PcSyncEngine(
@@ -135,6 +144,7 @@ return new class implements ServiceProviderInterface {
                 fieldMapRepo: $c->get(PcFieldMapRepositoryInterface::class),
                 fieldWriter: $c->get(PcCustomFieldWriterInterface::class),
                 photoCache: $c->get(PcPhotoCacheInterface::class),
+                pairing: $c->get(MemberPairingInterface::class),
             ),
         );
     }

--- a/admin/src/Service/Pairing/DatabaseMemberPairing.php
+++ b/admin/src/Service/Pairing/DatabaseMemberPairing.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Administrator\Service\Pairing;
+
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * DB-backed implementation of {@see MemberPairingInterface}. Production
+ * binding registered in admin/services/provider.php.
+ *
+ * Tolerates both pre-H.1 (`user_id INT NOT NULL DEFAULT 0`) and post-H.1
+ * (`user_id INT UNSIGNED NULL` + UNIQUE) schemas: the "unpaired" predicate
+ * is `(user_id IS NULL OR user_id = 0)`, which is true under either shape.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final readonly class DatabaseMemberPairing implements MemberPairingInterface
+{
+    public function __construct(private DatabaseInterface $db) {}
+
+    public function findUnpairedMemberIdByEmail(string $email): ?int
+    {
+        $email = trim($email);
+
+        if ($email === '') {
+            return null;
+        }
+
+        $query = $this->db->createQuery()
+            ->select($this->db->quoteName('id'))
+            ->from($this->db->quoteName('#__cwmconnect_details'))
+            ->where($this->db->quoteName('email_to') . ' = :email')
+            ->where('(' . $this->db->quoteName('user_id') . ' IS NULL OR '
+                . $this->db->quoteName('user_id') . ' = 0)')
+            ->where($this->db->quoteName('published') . ' > -2')
+            ->bind(':email', $email, ParameterType::STRING)
+            ->setLimit(2);
+
+        $ids = $this->db->setQuery($query)->loadColumn();
+
+        return \count($ids) === 1 ? (int) $ids[0] : null;
+    }
+
+    public function findJoomlaUserIdByEmail(string $email): ?int
+    {
+        $email = trim($email);
+
+        if ($email === '') {
+            return null;
+        }
+
+        $query = $this->db->createQuery()
+            ->select($this->db->quoteName('id'))
+            ->from($this->db->quoteName('#__users'))
+            ->where($this->db->quoteName('email') . ' = :email')
+            ->where($this->db->quoteName('block') . ' = 0')
+            ->bind(':email', $email, ParameterType::STRING)
+            ->setLimit(2);
+
+        $ids = $this->db->setQuery($query)->loadColumn();
+
+        return \count($ids) === 1 ? (int) $ids[0] : null;
+    }
+
+    public function pairMemberToUser(int $memberId, int $userId): bool
+    {
+        if ($memberId <= 0 || $userId <= 0) {
+            return false;
+        }
+
+        $query = $this->db->createQuery()
+            ->update($this->db->quoteName('#__cwmconnect_details'))
+            ->set($this->db->quoteName('user_id') . ' = :userId')
+            ->where($this->db->quoteName('id') . ' = :memberId')
+            ->where('(' . $this->db->quoteName('user_id') . ' IS NULL OR '
+                . $this->db->quoteName('user_id') . ' = 0)')
+            ->bind(':userId', $userId, ParameterType::INTEGER)
+            ->bind(':memberId', $memberId, ParameterType::INTEGER);
+
+        $this->db->setQuery($query)->execute();
+
+        return $this->db->getAffectedRows() === 1;
+    }
+}

--- a/admin/src/Service/Pairing/MemberPairingInterface.php
+++ b/admin/src/Service/Pairing/MemberPairingInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Administrator\Service\Pairing;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Identity-binding heuristic for the Phase H pairing triggers. Implements
+ * spec §8.2 — all four triggers (PC sync, admin manual pair, onUserAfterSave,
+ * locally-created member with email) share this single email-match contract
+ * so behaviour is identical regardless of which side fires first.
+ *
+ * The interface exists so the engine and the user plugin can both depend on
+ * a pure contract, and so tests can swap in an in-memory implementation
+ * without a real DB.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface MemberPairingInterface
+{
+    /**
+     * Look up the single unpaired member row that matches the given email.
+     *
+     * "Unpaired" tolerates both the pre-H.1 sentinel (`user_id = 0`) and the
+     * post-H.1 nullable column (`user_id IS NULL`) so this method works on
+     * either schema without branching.
+     *
+     * Returns null on zero matches AND on multiple matches — ambiguity is
+     * not resolved automatically; the spec defers conflict resolution to
+     * the admin (§8.2). Trashed rows (`published = -2`) are excluded.
+     *
+     * @param   string  $email  Email address to match against `email_to`.
+     *                          Case-insensitive (utf8mb4_unicode_ci).
+     *
+     * @return  int|null  Member row id, or null on no-match / ambiguous.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function findUnpairedMemberIdByEmail(string $email): ?int;
+
+    /**
+     * Look up the single Joomla user that matches the given email.
+     *
+     * Blocked accounts (`#__users.block = 1`) are excluded — pairing a
+     * member to a blocked user defeats the portal's purpose. Returns null
+     * on zero matches AND on multiple matches.
+     *
+     * @param   string  $email  Email to match against `#__users.email`.
+     *
+     * @return  int|null  Joomla user id, or null on no-match / ambiguous.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function findJoomlaUserIdByEmail(string $email): ?int;
+
+    /**
+     * Bind a Joomla user id to a member row, *only* if the row is currently
+     * unpaired. Returns true when the UPDATE affected one row (pair
+     * succeeded), false when the row was already paired or did not exist
+     * (no silent overwrite — admin must unlink first, per spec §8.2).
+     *
+     * @param   int  $memberId  `#__cwmconnect_details.id`
+     * @param   int  $userId    `#__users.id`
+     *
+     * @return  bool  True if the row was paired by this call.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function pairMemberToUser(int $memberId, int $userId): bool;
+}

--- a/admin/src/Service/Pc/SyncEngine.php
+++ b/admin/src/Service/Pc/SyncEngine.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace CWM\Component\Cwmconnect\Administrator\Service\Pc;
 
+use CWM\Component\Cwmconnect\Administrator\Service\Pairing\MemberPairingInterface;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\Exception\PcException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -48,6 +49,12 @@ use Psr\Log\NullLogger;
  *    differs from the stored `image_hash`
  *  - The new (relative path, hash) is written back via
  *    {@see MemberRepositoryInterface::updateImageByPcPersonId()}.
+ *
+ * Phase H adds identity-binding pair attempts (spec §8.2 trigger #1):
+ *  - After each per-person upsert, when the row is unpaired and the PC
+ *    person has an email, {@see MemberPairingInterface} looks up the
+ *    matching unblocked Joomla user and binds `user_id`. Ambiguous and
+ *    no-match emails are silently skipped — there's no error to log.
  *
  * Household + campus FK resolution remain deferred to later phases.
  *
@@ -113,6 +120,7 @@ final class SyncEngine
         private readonly ?FieldMapRepositoryInterface $fieldMapRepo = null,
         private readonly ?CustomFieldWriterInterface $fieldWriter = null,
         private readonly ?PhotoCacheInterface $photoCache = null,
+        private readonly ?MemberPairingInterface $pairing = null,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {}
 
@@ -187,6 +195,7 @@ final class SyncEngine
                         $seenIds[] = $pcPersonId;
                         $this->writeCustomFields($pcPersonId, $person, $included, $report);
                         $this->cacheAvatar($pcPersonId, $person, $report);
+                        $this->tryPairByEmail($pcPersonId, $attrs, $report);
                     }
                 } catch (\Throwable $e) {
                     $report->recordError($pcPersonId, $e->getMessage());
@@ -332,6 +341,63 @@ final class SyncEngine
         } catch (\Throwable $e) {
             $report->recordError($pcPersonId, 'Photo cache failed: ' . $e->getMessage());
             $this->logger->error('PC sync photo cache error.', [
+                'pcPersonId' => $pcPersonId,
+                'error'      => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Phase H: per-person identity-bind step (spec §8.2 trigger #1). No-op
+     * when the engine was constructed without a pairing service (Phase
+     * C/D/E parity), when the PC person has no email, or when no
+     * unblocked Joomla user matches that email.
+     *
+     * The pair call is a guarded UPDATE — already-paired rows are left
+     * alone, so this runs idempotently on every sync without ever
+     * overwriting an admin's manual binding.
+     *
+     * @param   int                   $pcPersonId
+     * @param   array<string, mixed>  $attrs   Mapped attrs returned by
+     *                                          PersonMapper::map(); read for
+     *                                          `email_to`.
+     * @param   SyncReport            $report  Mutated in-place.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function tryPairByEmail(int $pcPersonId, array $attrs, SyncReport $report): void
+    {
+        if ($this->pairing === null) {
+            return;
+        }
+
+        $email = isset($attrs['email_to']) && \is_string($attrs['email_to']) ? trim($attrs['email_to']) : '';
+
+        if ($email === '') {
+            return;
+        }
+
+        try {
+            $memberId = $this->repository->findIdByPcPersonId($pcPersonId);
+
+            if ($memberId === null) {
+                return;
+            }
+
+            $userId = $this->pairing->findJoomlaUserIdByEmail($email);
+
+            if ($userId === null) {
+                return;
+            }
+
+            if ($this->pairing->pairMemberToUser($memberId, $userId)) {
+                $report->paired++;
+            }
+        } catch (\Throwable $e) {
+            $report->recordError($pcPersonId, 'Pair-by-email failed: ' . $e->getMessage());
+            $this->logger->error('PC sync pair-by-email error.', [
                 'pcPersonId' => $pcPersonId,
                 'error'      => $e->getMessage(),
             ]);

--- a/admin/src/Service/Pc/SyncReport.php
+++ b/admin/src/Service/Pc/SyncReport.php
@@ -100,6 +100,17 @@ final class SyncReport
     public int $photosUnchanged = 0;
 
     /**
+     * Phase H: member rows newly paired to a Joomla user this run via the
+     * email-match heuristic (spec §8.2 trigger #1). Members already paired,
+     * unmatched emails, and ambiguous matches do NOT increment this — only
+     * successful state changes from unpaired → paired count.
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    public int $paired = 0;
+
+    /**
      * Per-person error list, one entry per failure.
      *
      * @var    list<array{pcPersonId: int|null, message: string}>
@@ -222,6 +233,7 @@ final class SyncReport
             'customFieldsWritten' => $this->customFieldsWritten,
             'photosDownloaded'    => $this->photosDownloaded,
             'photosUnchanged'     => $this->photosUnchanged,
+            'paired'              => $this->paired,
             'errorCount'       => $this->errorCount(),
             'errors'           => $this->errors,
             'startedAt'        => $this->startedAt->format(\DateTimeImmutable::ATOM),

--- a/build/pkg_cwmconnect.xml
+++ b/build/pkg_cwmconnect.xml
@@ -17,6 +17,7 @@
         <file type="component" id="com_cwmconnect">com_cwmconnect.zip</file>
         <file type="module" client="site" id="mod_birthdayanniversary">mod_birthdayanniversary.zip</file>
         <file type="plugin" group="finder" id="cwmconnect">plg_finder_cwmconnect.zip</file>
+        <file type="plugin" group="user" id="cwmconnect">plg_user_cwmconnect.zip</file>
     </files>
 
     <updateservers>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "autoload": {
         "psr-4": {
             "CWM\\Component\\Cwmconnect\\Administrator\\": "admin/src/",
-            "CWM\\Component\\Cwmconnect\\Site\\": "site/src/"
+            "CWM\\Component\\Cwmconnect\\Site\\": "site/src/",
+            "CWM\\Plugin\\User\\Cwmconnect\\": "plugins/user/cwmconnect/src/"
         }
     },
     "autoload-dev": {

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -16,7 +16,8 @@
         "extensions": [
             { "type": "component", "path": "cwmconnect.xml" },
             { "type": "module",    "path": "modules/site/mod_birthdayanniversary/mod_birthdayanniversary.xml" },
-            { "type": "plugin",    "path": "plugins/finder/cwmconnect/cwmconnect.xml" }
+            { "type": "plugin",    "path": "plugins/finder/cwmconnect/cwmconnect.xml" },
+            { "type": "plugin",    "path": "plugins/user/cwmconnect/cwmconnect.xml" }
         ]
     },
     "build": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
             <directory>site/src</directory>
             <directory>modules/site/mod_birthdayanniversary/src</directory>
             <directory>plugins/finder/cwmconnect/src</directory>
+            <directory>plugins/user/cwmconnect/src</directory>
         </include>
     </source>
 </phpunit>

--- a/plugins/user/cwmconnect/cwmconnect.xml
+++ b/plugins/user/cwmconnect/cwmconnect.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="user" method="upgrade">
+    <name>plg_user_cwmconnect</name>
+    <author>CWM Team</author>
+    <authorEmail>info@christianwebministries.org</authorEmail>
+    <authorUrl>www.christianwebministries.org</authorUrl>
+    <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
+    <creationDate>2026-05-20</creationDate>
+    <version>2.0.0-dev</version>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <description>PLG_USER_CWMCONNECT_XML_DESCRIPTION</description>
+    <namespace path="src">CWM\Plugin\User\Cwmconnect</namespace>
+
+    <compatibility>
+        <cms>
+            <targetplatform name="joomla" version="5[.0-9]" />
+            <targetplatform name="joomla" version="6[.0-9]" />
+        </cms>
+        <php minimum="8.4.0" />
+    </compatibility>
+
+    <files>
+        <folder plugin="cwmconnect">services</folder>
+        <folder>src</folder>
+    </files>
+
+    <languages>
+        <language tag="en-GB">language/en-GB/plg_user_cwmconnect.ini</language>
+        <language tag="en-GB">language/en-GB/plg_user_cwmconnect.sys.ini</language>
+    </languages>
+</extension>

--- a/plugins/user/cwmconnect/language/en-GB/index.html
+++ b/plugins/user/cwmconnect/language/en-GB/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/plugins/user/cwmconnect/language/en-GB/plg_user_cwmconnect.ini
+++ b/plugins/user/cwmconnect/language/en-GB/plg_user_cwmconnect.ini
@@ -1,0 +1,7 @@
+; @package    Plg_User_Cwmconnect
+; @copyright  (C) 2026 CWM Team All rights reserved
+; @license    GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_USER_CWMCONNECT="User - CWM Connect pairing"
+PLG_USER_CWMCONNECT_XML_DESCRIPTION="When a Joomla user account is saved, pair it to the matching CWM Connect member row by email (Phase H pairing trigger)."

--- a/plugins/user/cwmconnect/language/en-GB/plg_user_cwmconnect.sys.ini
+++ b/plugins/user/cwmconnect/language/en-GB/plg_user_cwmconnect.sys.ini
@@ -1,0 +1,7 @@
+; @package    Plg_User_Cwmconnect
+; @copyright  (C) 2026 CWM Team All rights reserved
+; @license    GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8 - No BOM
+
+PLG_USER_CWMCONNECT="User - CWM Connect pairing"
+PLG_USER_CWMCONNECT_XML_DESCRIPTION="When a Joomla user account is saved, pair it to the matching CWM Connect member row by email (Phase H pairing trigger)."

--- a/plugins/user/cwmconnect/language/index.html
+++ b/plugins/user/cwmconnect/language/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/plugins/user/cwmconnect/services/provider.php
+++ b/plugins/user/cwmconnect/services/provider.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @package    Plg_User_Cwmconnect
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+\defined('_JEXEC') or die;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pairing\DatabaseMemberPairing;
+use CWM\Plugin\User\Cwmconnect\Extension\Cwmconnect;
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+return new class implements ServiceProviderInterface {
+    public function register(Container $container): void
+    {
+        $container->set(
+            PluginInterface::class,
+            $container->lazy(Cwmconnect::class, function (Container $container) {
+                $pairing = new DatabaseMemberPairing($container->get(DatabaseInterface::class));
+                $plugin  = new Cwmconnect(
+                    (array) PluginHelper::getPlugin('user', 'cwmconnect'),
+                    $pairing,
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            })
+        );
+    }
+};

--- a/plugins/user/cwmconnect/src/Extension/Cwmconnect.php
+++ b/plugins/user/cwmconnect/src/Extension/Cwmconnect.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @package    Plg_User_Cwmconnect
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Plugin\User\Cwmconnect\Extension;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pairing\MemberPairingInterface;
+use Joomla\CMS\Event\User\AfterSaveEvent;
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Event\SubscriberInterface;
+
+/**
+ * User plugin — Phase H trigger #3: when a Joomla user is saved, try to
+ * pair the account to an unpaired member row that shares the same email
+ * address (spec §8.2).
+ *
+ * Fires on every save (create, edit, activation) but only acts when:
+ *  - the save succeeded,
+ *  - the user is active (block = 0), so we don't pair to pending accounts,
+ *  - the user has a non-empty email, and
+ *  - exactly one unpaired member shares that email.
+ *
+ * The pair call itself is guarded — already-paired members are never
+ * overwritten. Ambiguous matches (two members with the same email) are
+ * silently skipped; the admin must resolve them via the manual pair UI.
+ *
+ * @since  2.0.0
+ */
+final class Cwmconnect extends CMSPlugin implements SubscriberInterface
+{
+    /** @var bool */
+    protected $autoloadLanguage = true;
+
+    public function __construct(
+        array $config,
+        private readonly MemberPairingInterface $pairing,
+    ) {
+        parent::__construct(null, $config);
+    }
+
+    /**
+     * @return  array<string, string>
+     *
+     * @since  2.0.0
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onUserAfterSave' => 'onUserAfterSave',
+        ];
+    }
+
+    /**
+     * Handle a successful user save. Best-effort: a pair failure does not
+     * interrupt the user save (the event has already happened).
+     *
+     * @since  2.0.0
+     */
+    public function onUserAfterSave(AfterSaveEvent $event): void
+    {
+        if (!$event->getSavingResult()) {
+            return;
+        }
+
+        $user   = $event->getUser();
+        $userId = (int) ($user['id'] ?? 0);
+        $email  = isset($user['email']) && \is_string($user['email']) ? trim($user['email']) : '';
+        $block  = (int) ($user['block'] ?? 1);
+
+        if ($userId <= 0 || $email === '' || $block !== 0) {
+            return;
+        }
+
+        $memberId = $this->pairing->findUnpairedMemberIdByEmail($email);
+
+        if ($memberId === null) {
+            return;
+        }
+
+        $this->pairing->pairMemberToUser($memberId, $userId);
+    }
+}

--- a/tests/stubs/Joomla/CMS/Event/User/AfterSaveEvent.php
+++ b/tests/stubs/Joomla/CMS/Event/User/AfterSaveEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Joomla\CMS\Event\User;
+
+/**
+ * Minimal stub of Joomla\CMS\Event\User\AfterSaveEvent for unit tests.
+ *
+ * Mirrors just the getters our plugin handler reads. Production class
+ * derives from a Joomla\Event\Event chain we don't need under test.
+ */
+class AfterSaveEvent
+{
+    /**
+     * @param  array<string, mixed>  $user
+     */
+    public function __construct(
+        private readonly array $user,
+        private readonly bool $isNew,
+        private readonly bool $savingResult,
+        private readonly ?string $errorMessage = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getUser(): array
+    {
+        return $this->user;
+    }
+
+    public function getIsNew(): bool
+    {
+        return $this->isNew;
+    }
+
+    public function getSavingResult(): bool
+    {
+        return $this->savingResult;
+    }
+
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage ?? '';
+    }
+}

--- a/tests/stubs/Joomla/CMS/Plugin/CMSPlugin.php
+++ b/tests/stubs/Joomla/CMS/Plugin/CMSPlugin.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Joomla\CMS\Plugin;
+
+/**
+ * Minimal stub of joomla/cms's CMSPlugin base class for unit tests.
+ *
+ * Production CMSPlugin pulls in DispatcherAwareInterface, ApplicationAware,
+ * language loading, etc. Our plugin only relies on being constructible
+ * and on declaring `autoloadLanguage`; tests don't exercise the wider
+ * surface.
+ */
+abstract class CMSPlugin
+{
+    /** @var bool */
+    protected $autoloadLanguage = false;
+
+    /**
+     * @param  mixed                 $subject  Production passes a Dispatcher; tests pass null.
+     * @param  array<string, mixed>  $config   The plugin's config row.
+     */
+    public function __construct($subject = null, array $config = [])
+    {
+        // No-op for test purposes. Production stores the dispatcher
+        // and reads `params` from $config.
+    }
+
+    /**
+     * Joomla calls setApplication on plugins resolved through the DI
+     * container. We just need the method to exist so the service
+     * provider can call it without blowing up under tests.
+     *
+     * @param  mixed  $app
+     */
+    public function setApplication($app): void
+    {
+        // No-op for test purposes.
+    }
+}

--- a/tests/stubs/Joomla/Event/SubscriberInterface.php
+++ b/tests/stubs/Joomla/Event/SubscriberInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Joomla\Event;
+
+/**
+ * Minimal stub of joomla/event's SubscriberInterface for unit tests.
+ * Mirrors the production contract: a static map from event name to
+ * handler method name (or array of names).
+ */
+interface SubscriberInterface
+{
+    /**
+     * @return array<string, string|array<int, string>>
+     */
+    public static function getSubscribedEvents(): array;
+}

--- a/tests/unit/Plugin/User/Cwmconnect/CwmconnectTest.php
+++ b/tests/unit/Plugin/User/Cwmconnect/CwmconnectTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Plugin\User\Cwmconnect;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pairing\MemberPairingInterface;
+use CWM\Plugin\User\Cwmconnect\Extension\Cwmconnect;
+use Joomla\CMS\Event\User\AfterSaveEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase H pairing trigger #3: plg_user_cwmconnect's onUserAfterSave.
+ *
+ * Decision matrix:
+ *  - save result false                  → no pair attempt
+ *  - user blocked (block != 0)          → no pair attempt
+ *  - user has no email                  → no pair attempt
+ *  - email present, no matching member  → no pair attempt
+ *  - email present, member match found  → pairMemberToUser called once
+ */
+#[CoversClass(Cwmconnect::class)]
+final class CwmconnectTest extends TestCase
+{
+    #[Test]
+    public function failedSaveSkipsPairing(): void
+    {
+        $pairing = $this->stubPairing();
+        $plugin  = $this->makePlugin($pairing);
+
+        $plugin->onUserAfterSave($this->event(
+            user: ['id' => 7, 'email' => 'a@example.com', 'block' => 0],
+            savingResult: false,
+        ));
+
+        self::assertSame(0, $pairing->memberLookups);
+        self::assertSame(0, $pairing->pairCalls);
+    }
+
+    #[Test]
+    public function blockedUserSkipsPairing(): void
+    {
+        $pairing = $this->stubPairing(memberIdByEmail: ['a@example.com' => 100]);
+        $plugin  = $this->makePlugin($pairing);
+
+        $plugin->onUserAfterSave($this->event(
+            user: ['id' => 7, 'email' => 'a@example.com', 'block' => 1],
+            savingResult: true,
+        ));
+
+        self::assertSame(0, $pairing->memberLookups);
+        self::assertSame(0, $pairing->pairCalls);
+    }
+
+    #[Test]
+    public function missingEmailSkipsPairing(): void
+    {
+        $pairing = $this->stubPairing();
+        $plugin  = $this->makePlugin($pairing);
+
+        $plugin->onUserAfterSave($this->event(
+            user: ['id' => 7, 'email' => '', 'block' => 0],
+            savingResult: true,
+        ));
+
+        self::assertSame(0, $pairing->memberLookups);
+        self::assertSame(0, $pairing->pairCalls);
+    }
+
+    #[Test]
+    public function noMatchingMemberLooksUpButDoesNotPair(): void
+    {
+        $pairing = $this->stubPairing(memberIdByEmail: []);  // no match
+        $plugin  = $this->makePlugin($pairing);
+
+        $plugin->onUserAfterSave($this->event(
+            user: ['id' => 7, 'email' => 'nobody@example.com', 'block' => 0],
+            savingResult: true,
+        ));
+
+        self::assertSame(1, $pairing->memberLookups);
+        self::assertSame(0, $pairing->pairCalls);
+    }
+
+    #[Test]
+    public function matchingMemberTriggersExactlyOnePairCall(): void
+    {
+        $pairing = $this->stubPairing(memberIdByEmail: ['alice@example.com' => 99]);
+        $plugin  = $this->makePlugin($pairing);
+
+        $plugin->onUserAfterSave($this->event(
+            user: ['id' => 7, 'email' => 'alice@example.com', 'block' => 0],
+            savingResult: true,
+        ));
+
+        self::assertSame(1, $pairing->memberLookups);
+        self::assertSame(1, $pairing->pairCalls);
+        self::assertSame(
+            [['memberId' => 99, 'userId' => 7]],
+            $pairing->pairCaptured,
+        );
+    }
+
+    private function makePlugin(MemberPairingInterface $pairing): Cwmconnect
+    {
+        return new Cwmconnect([], $pairing);
+    }
+
+    /**
+     * @param  array<string, mixed>  $user
+     */
+    private function event(array $user, bool $savingResult, bool $isNew = true): AfterSaveEvent
+    {
+        return new AfterSaveEvent($user, $isNew, $savingResult);
+    }
+
+    /**
+     * @param  array<string, int>  $memberIdByEmail
+     */
+    private function stubPairing(array $memberIdByEmail = [], bool $pairResult = true): MemberPairingInterface
+    {
+        return new class ($memberIdByEmail, $pairResult) implements MemberPairingInterface {
+            public int $memberLookups = 0;
+
+            public int $pairCalls = 0;
+
+            /** @var list<array{memberId: int, userId: int}> */
+            public array $pairCaptured = [];
+
+            /** @param array<string, int> $memberIdByEmail */
+            public function __construct(private array $memberIdByEmail, private bool $pairResult) {}
+
+            public function findUnpairedMemberIdByEmail(string $email): ?int
+            {
+                $this->memberLookups++;
+
+                return $this->memberIdByEmail[$email] ?? null;
+            }
+
+            public function findJoomlaUserIdByEmail(string $email): ?int
+            {
+                return null;  // not used by the user-side trigger
+            }
+
+            public function pairMemberToUser(int $memberId, int $userId): bool
+            {
+                $this->pairCalls++;
+                $this->pairCaptured[] = ['memberId' => $memberId, 'userId' => $userId];
+
+                return $this->pairResult;
+            }
+        };
+    }
+}

--- a/tests/unit/Service/Pc/SyncEnginePhaseHTest.php
+++ b/tests/unit/Service/Pc/SyncEnginePhaseHTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Service\Pc;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Pairing\MemberPairingInterface;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\Client;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\MemberRepositoryInterface;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\PersonMapper;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\SyncEngine;
+use CWM\Component\Cwmconnect\Administrator\Service\Pc\UpsertOutcome;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase H: SyncEngine email-match pairing step (spec §8.2 trigger #1).
+ *
+ * Decision matrix:
+ *  - no pairing service wired                           → never call repo
+ *  - PC person has no email                             → never call pairing
+ *  - email present, no Joomla user matches              → no pair, no error
+ *  - email present, user matches, member already paired → no counter bump
+ *  - email present, user matches, pair succeeds         → report.paired++
+ *  - pairing throws                                     → captured in errors
+ */
+#[CoversClass(SyncEngine::class)]
+final class SyncEnginePhaseHTest extends TestCase
+{
+    #[Test]
+    public function pairingIsSkippedEntirelyWhenNoServiceIsWired(): void
+    {
+        $client  = $this->clientReturning($this->pageWith($this->personWithEmail(1, 'a@example.com')));
+        $repo    = $this->stubRepo();
+
+        $report = new SyncEngine($client, $repo, new PersonMapper())->run([]);
+
+        self::assertSame(0, $report->paired);
+        self::assertTrue($report->success());
+    }
+
+    #[Test]
+    public function personWithoutEmailDoesNotConsultPairingService(): void
+    {
+        $client  = $this->clientReturning($this->pageWith($this->personWithEmail(1, null)));
+        $repo    = $this->stubRepo();
+        $pairing = $this->stubPairing();
+
+        $report = new SyncEngine(
+            $client,
+            $repo,
+            new PersonMapper(),
+            null,
+            null,
+            null,
+            $pairing,
+        )->run([]);
+
+        self::assertSame(0, $report->paired);
+        self::assertSame(0, $pairing->userLookups);
+        self::assertSame(0, $pairing->pairCalls);
+    }
+
+    #[Test]
+    public function emailWithNoMatchingUserSkipsPair(): void
+    {
+        $client  = $this->clientReturning($this->pageWith($this->personWithEmail(1, 'nobody@example.com')));
+        $repo    = $this->stubRepo();
+        $pairing = $this->stubPairing(userIdByEmail: []);  // no users match
+
+        $report = new SyncEngine(
+            $client,
+            $repo,
+            new PersonMapper(),
+            null,
+            null,
+            null,
+            $pairing,
+        )->run([]);
+
+        self::assertSame(0, $report->paired);
+        self::assertSame(1, $pairing->userLookups);
+        self::assertSame(0, $pairing->pairCalls);
+    }
+
+    #[Test]
+    public function matchingEmailIncrementsPairedAndCallsPairExactlyOnce(): void
+    {
+        $client  = $this->clientReturning($this->pageWith($this->personWithEmail(1, 'alice@example.com')));
+        $repo    = $this->stubRepo();
+        $pairing = $this->stubPairing(
+            userIdByEmail: ['alice@example.com' => 42],
+            pairResult: true,
+        );
+
+        $report = new SyncEngine(
+            $client,
+            $repo,
+            new PersonMapper(),
+            null,
+            null,
+            null,
+            $pairing,
+        )->run([]);
+
+        self::assertSame(1, $report->paired);
+        self::assertSame(1, $pairing->pairCalls);
+        self::assertSame(
+            [['memberId' => 1001, 'userId' => 42]],
+            $pairing->pairCaptured,
+        );
+    }
+
+    #[Test]
+    public function alreadyPairedMemberDoesNotIncrementCounter(): void
+    {
+        $client  = $this->clientReturning($this->pageWith($this->personWithEmail(1, 'alice@example.com')));
+        $repo    = $this->stubRepo();
+        $pairing = $this->stubPairing(
+            userIdByEmail: ['alice@example.com' => 42],
+            pairResult: false,  // UPDATE affected 0 rows = already paired
+        );
+
+        $report = new SyncEngine(
+            $client,
+            $repo,
+            new PersonMapper(),
+            null,
+            null,
+            null,
+            $pairing,
+        )->run([]);
+
+        self::assertSame(0, $report->paired);
+        self::assertSame(1, $pairing->pairCalls);
+        self::assertTrue($report->success());
+    }
+
+    #[Test]
+    public function pairingExceptionIsCapturedAndDoesNotAbortRun(): void
+    {
+        $client  = $this->clientReturning($this->pageWith($this->personWithEmail(1, 'boom@example.com')));
+        $repo    = $this->stubRepo();
+        $pairing = $this->stubPairingThatThrows();
+
+        $report = new SyncEngine(
+            $client,
+            $repo,
+            new PersonMapper(),
+            null,
+            null,
+            null,
+            $pairing,
+        )->run([]);
+
+        self::assertSame(0, $report->paired);
+        self::assertSame(1, $report->errorCount());
+        self::assertStringContainsString('Pair-by-email', $report->errors[0]['message']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $page
+     */
+    private function clientReturning(array $page): Client
+    {
+        return new class ($page) extends Client {
+            public function __construct(private array $page)
+            {
+                // bypass parent
+            }
+
+            public function getJson(string $path, array $query = []): array
+            {
+                return $this->page;
+            }
+
+            public function getJsonAbsolute(string $url): array
+            {
+                return ['data' => [], 'included' => [], 'links' => []];
+            }
+        };
+    }
+
+    private function stubRepo(): MemberRepositoryInterface
+    {
+        return new class implements MemberRepositoryInterface {
+            public function upsertByPcPersonId(array $attrs): UpsertOutcome
+            {
+                return UpsertOutcome::Added;
+            }
+
+            public function archiveMissingPcPersonIds(array $seenPcPersonIds): int
+            {
+                return 0;
+            }
+
+            public function findIdByPcPersonId(int $pcPersonId): ?int
+            {
+                return 1000 + $pcPersonId;
+            }
+
+            public function updateImageByPcPersonId(int $pcPersonId, string $relativePath, string $hash): void
+            {
+                // not exercised in pair tests
+            }
+
+            public function findImageHashByPcPersonId(int $pcPersonId): ?string
+            {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * @param  array<string, int>  $userIdByEmail
+     */
+    private function stubPairing(array $userIdByEmail = [], bool $pairResult = true): MemberPairingInterface
+    {
+        return new class ($userIdByEmail, $pairResult) implements MemberPairingInterface {
+            public int $userLookups = 0;
+
+            public int $pairCalls = 0;
+
+            /** @var list<array{memberId: int, userId: int}> */
+            public array $pairCaptured = [];
+
+            /** @param array<string, int> $userIdByEmail */
+            public function __construct(private array $userIdByEmail, private bool $pairResult) {}
+
+            public function findUnpairedMemberIdByEmail(string $email): ?int
+            {
+                // Engine does not invoke this on the PC-sync trigger — it
+                // already knows the member id via findIdByPcPersonId.
+                return null;
+            }
+
+            public function findJoomlaUserIdByEmail(string $email): ?int
+            {
+                $this->userLookups++;
+
+                return $this->userIdByEmail[$email] ?? null;
+            }
+
+            public function pairMemberToUser(int $memberId, int $userId): bool
+            {
+                $this->pairCalls++;
+                $this->pairCaptured[] = ['memberId' => $memberId, 'userId' => $userId];
+
+                return $this->pairResult;
+            }
+        };
+    }
+
+    private function stubPairingThatThrows(): MemberPairingInterface
+    {
+        return new class implements MemberPairingInterface {
+            public function findUnpairedMemberIdByEmail(string $email): ?int
+            {
+                return null;
+            }
+
+            public function findJoomlaUserIdByEmail(string $email): ?int
+            {
+                throw new \RuntimeException('DB down');
+            }
+
+            public function pairMemberToUser(int $memberId, int $userId): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * @param  array{0: list<array<string, mixed>>, 1: list<array<string, mixed>>}  $dataAndIncluded
+     *
+     * @return array<string, mixed>
+     */
+    private function pageWith(array $dataAndIncluded): array
+    {
+        return [
+            'data'     => $dataAndIncluded[0],
+            'included' => $dataAndIncluded[1],
+            'links'    => [],
+        ];
+    }
+
+    /**
+     * @return array{0: list<array<string, mixed>>, 1: list<array<string, mixed>>}
+     */
+    private function personWithEmail(int $personId, ?string $email): array
+    {
+        $person = [
+            'type'          => 'Person',
+            'id'            => (string) $personId,
+            'attributes'    => ['first_name' => 'Alice', 'last_name' => 'Test'],
+            'relationships' => [],
+        ];
+
+        $included = [];
+
+        if ($email !== null) {
+            $person['relationships']['emails'] = [
+                'data' => [['type' => 'Email', 'id' => 'em-' . $personId]],
+            ];
+
+            $included[] = [
+                'type'       => 'Email',
+                'id'         => 'em-' . $personId,
+                'attributes' => ['address' => $email, 'primary' => true],
+            ];
+        }
+
+        return [[$person], $included];
+    }
+}


### PR DESCRIPTION
## Summary

Spec §8.2 pairing triggers #1 (PC sync, email-match) and #3 (`onUserAfterSave`). Both delegate to the same `MemberPairing` service so the heuristic is identical regardless of which side fires first.

**Relationship to H.1 (#124):** H.1 lands the schema half (nullable, UNIQUE `user_id`). H.2 works on either schema shape — "unpaired" is encoded as `(user_id IS NULL OR user_id = 0)` so the pair guard tolerates the pre-H.1 `INT(11) NOT NULL DEFAULT 0` sentinel AND the post-H.1 nullable UNIQUE column.

Mergeable independently in either order, but H.1 should land first so the UNIQUE constraint backs up the "no overwrite" guarantee.

## Service contract (`admin/src/Service/Pairing/`)

`MemberPairingInterface` — three small methods, all used by both triggers:

| Method | Returns |
|---|---|
| `findUnpairedMemberIdByEmail(string)` | Single unpaired `#__cwmconnect_details.id` whose `email_to` matches; null on zero/multiple |
| `findJoomlaUserIdByEmail(string)` | Single unblocked `#__users.id` whose `email` matches; null on zero/multiple |
| `pairMemberToUser(int memberId, int userId)` | True iff the guarded UPDATE affected a row (was unpaired, is now paired) |

`DatabaseMemberPairing` is the production binding, registered in `admin/services/provider.php`. Excludes trashed rows (`published = -2`) on the member-side lookup and blocked accounts (`block = 0`) on the user-side lookup.

## SyncEngine trigger (PC sync)

- Constructor grows optional `MemberPairingInterface` (Phase C/D/E parity preserved when null).
- New `tryPairByEmail()` per-person step runs after upsert + custom-fields + avatar cache. Reads `email_to` from the mapped attrs — no extra PC roundtrip.
- `SyncReport` gains a `paired` counter. Incremented only on successful unpaired → paired transitions.
- Exceptions captured per-person via `report.errors[]` — one bad lookup doesn't abort the run.

## User plugin trigger (`plg_user_cwmconnect`)

- New plugin under `plugins/user/cwmconnect/` — `SubscriberInterface` + `CMSPlugin` base; service provider injects `MemberPairing` via DI.
- `onUserAfterSave(AfterSaveEvent)` fires the email-match in reverse (Joomla user → unpaired member). Skips when:
  - save failed
  - user is blocked (`block != 0`) — registration confirmation will re-fire this with `block = 0` and pick the pair up then
  - email is empty
- Best-effort: a pair failure never interrupts the user save.
- Wired into `build/pkg_cwmconnect.xml`, `cwm-build.config.json` (version-tracking + linker), `composer.json` (PSR-4), `phpunit.xml` (coverage source).

## Tests

101 pass (11 new):

| Suite | Cases | Decision matrix |
|---|---|---|
| `SyncEnginePhaseHTest` | 6 | no service / no email / no user match / match-and-pair / already-paired / pairing throws |
| `PluginUserCwmconnectTest` | 5 | failed save / blocked / no email / no member match / match-and-pair |

Three thin Joomla stubs under `tests/stubs/` (SubscriberInterface, CMSPlugin, AfterSaveEvent) so the plugin's framework dependencies don't pull joomla-cms into `composer require`.

## What this does NOT include

H.3 (member self-service portal):
- `view=myprofile` controller/model/view
- Locked rendering (read-only PC-mapped fields + "Update your info in Planning Center" link)
- Edit-conflict short-circuit in the portal controller
- `onContentAfterSave` listener for spec §8.2 trigger #4 (member created locally with email). The other three triggers are wired here.

## Test plan

- [x] `composer check` — 101/101 tests pass, lint clean.
- [ ] Install plg_user_cwmconnect in a J5/J6 dev install. Create a Joomla user with email matching an existing unpaired member row → confirm `user_id` is populated, audit log clean.
- [ ] Create two member rows with the same email, leave both unpaired. Save a matching Joomla user → confirm neither row pairs (ambiguous), no error surfaced.
- [ ] Run a PC sync against a fixture where one PC person's email matches one Joomla user → confirm SyncReport shows `paired: 1` and the row is bound.
- [ ] Re-run the sync → confirm `paired: 0` on the second pass (already paired, guarded UPDATE no-ops).
- [ ] Manually pair a different Joomla user to that member via admin form, then sync again → confirm the admin's pair is not overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)