### PR TITLE
Phase L: GDPR privacy plugin (plg_privacy_cwmconnect)

### DIFF
--- a/build/pkg_cwmconnect.xml
+++ b/build/pkg_cwmconnect.xml
@@ -20,6 +20,7 @@
         <file type="plugin" group="finder" id="cwmconnect">plg_finder_cwmconnect.zip</file>
         <file type="plugin" group="user" id="cwmconnect">plg_user_cwmconnect.zip</file>
         <file type="plugin" group="content" id="cwmconnect">plg_content_cwmconnect.zip</file>
+        <file type="plugin" group="privacy" id="cwmconnect">plg_privacy_cwmconnect.zip</file>
     </files>
 
     <updateservers>

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
             "CWM\\Component\\Cwmconnect\\Administrator\\": "admin/src/",
             "CWM\\Component\\Cwmconnect\\Site\\": "site/src/",
             "CWM\\Plugin\\User\\Cwmconnect\\": "plugins/user/cwmconnect/src/",
-            "CWM\\Plugin\\Content\\Cwmconnect\\": "plugins/content/cwmconnect/src/"
+            "CWM\\Plugin\\Content\\Cwmconnect\\": "plugins/content/cwmconnect/src/",
+            "CWM\\Plugin\\Privacy\\Cwmconnect\\": "plugins/privacy/cwmconnect/src/"
         }
     },
     "autoload-dev": {

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -19,7 +19,8 @@
             { "type": "plugin",    "path": "plugins/finder/cwmconnect/cwmconnect.xml" },
             { "type": "plugin",    "path": "plugins/user/cwmconnect/cwmconnect.xml" },
             { "type": "plugin",    "path": "plugins/content/cwmconnect/cwmconnect.xml" },
-            { "type": "library",   "path": "libraries/mpdf/mpdf.xml" }
+            { "type": "library",   "path": "libraries/mpdf/mpdf.xml" },
+            { "type": "plugin",    "path": "plugins/privacy/cwmconnect/cwmconnect.xml" }
         ]
     },
     "build": {

--- a/plugins/privacy/cwmconnect/cwmconnect.xml
+++ b/plugins/privacy/cwmconnect/cwmconnect.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="privacy" method="upgrade">
+    <name>plg_privacy_cwmconnect</name>
+    <author>CWM Team</author>
+    <authorEmail>info@christianwebministries.org</authorEmail>
+    <authorUrl>https://www.christianwebministries.org</authorUrl>
+    <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <version>2.0.0-dev</version>
+    <creationDate>2026-05-26</creationDate>
+    <description>PLG_PRIVACY_CWMCONNECT_XML_DESCRIPTION</description>
+    <namespace path="src">CWM\Plugin\Privacy\Cwmconnect</namespace>
+
+    <files>
+        <folder>services</folder>
+        <folder>src</folder>
+        <folder>language</folder>
+    </files>
+
+    <languages folder="language">
+        <language tag="en-GB">en-GB/plg_privacy_cwmconnect.ini</language>
+        <language tag="en-GB">en-GB/plg_privacy_cwmconnect.sys.ini</language>
+    </languages>
+</extension>

--- a/plugins/privacy/cwmconnect/language/en-GB/plg_privacy_cwmconnect.ini
+++ b/plugins/privacy/cwmconnect/language/en-GB/plg_privacy_cwmconnect.ini
@@ -1,0 +1,2 @@
+PLG_PRIVACY_CWMCONNECT_MEMBER_DATA="CWM Connect member directory data"
+PLG_PRIVACY_CWMCONNECT_FEED_TOKEN_DATA="CWM Connect KML feed tokens"

--- a/plugins/privacy/cwmconnect/language/en-GB/plg_privacy_cwmconnect.sys.ini
+++ b/plugins/privacy/cwmconnect/language/en-GB/plg_privacy_cwmconnect.sys.ini
@@ -1,0 +1,2 @@
+PLG_PRIVACY_CWMCONNECT="CWM Connect - Privacy"
+PLG_PRIVACY_CWMCONNECT_XML_DESCRIPTION="GDPR privacy plugin for CWM Connect. Handles data export and pseudonymisation of member directory records and feed tokens."

--- a/plugins/privacy/cwmconnect/services/provider.php
+++ b/plugins/privacy/cwmconnect/services/provider.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package    Plg_Privacy_Cwmconnect
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+\defined('_JEXEC') or die;
+
+use CWM\Plugin\Privacy\Cwmconnect\Extension\Cwmconnect;
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+return new class implements ServiceProviderInterface {
+    /**
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container): void
+    {
+        $container->set(
+            PluginInterface::class,
+            $container->lazy(Cwmconnect::class, function (Container $container) {
+                $plugin = new Cwmconnect(
+                    (array) PluginHelper::getPlugin('privacy', 'cwmconnect'),
+                );
+                $plugin->setApplication(Factory::getApplication());
+                $plugin->setDatabase($container->get(DatabaseInterface::class));
+
+                return $plugin;
+            })
+        );
+    }
+};

--- a/plugins/privacy/cwmconnect/src/Extension/Cwmconnect.php
+++ b/plugins/privacy/cwmconnect/src/Extension/Cwmconnect.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * @package    Plg_Privacy_Cwmconnect
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Plugin\Privacy\Cwmconnect\Extension;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Event\Privacy\ExportRequestEvent;
+use Joomla\CMS\Event\Privacy\RemoveDataEvent;
+use Joomla\Component\Privacy\Administrator\Plugin\PrivacyPlugin;
+use Joomla\Database\ParameterType;
+use Joomla\Event\SubscriberInterface;
+
+/**
+ * Phase L: GDPR privacy plugin for CWM Connect member data.
+ *
+ * Handles two privacy events:
+ *  - **Export**: collects all member data linked to the requesting user
+ *    (via user_id FK) and any feed tokens they own.
+ *  - **Remove**: pseudonymises the member row (clears personal fields,
+ *    sets display_in_directory=0) and revokes all feed tokens.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class Cwmconnect extends PrivacyPlugin implements SubscriberInterface
+{
+    /**
+     * @return  array<string, string>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onPrivacyExportRequest' => 'onPrivacyExportRequest',
+            'onPrivacyRemoveData'    => 'onPrivacyRemoveData',
+        ];
+    }
+
+    /**
+     * Export member data and feed tokens for a privacy request.
+     *
+     * @param   ExportRequestEvent  $event  The export request event.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function onPrivacyExportRequest(ExportRequestEvent $event): void
+    {
+        $user = $event->getUser();
+
+        if (!$user) {
+            return;
+        }
+
+        $domains = [];
+        $db      = $this->getDatabase();
+
+        $query = $db->createQuery()
+            ->select('*')
+            ->from($db->quoteName('#__cwmconnect_details'))
+            ->where($db->quoteName('user_id') . ' = :userId')
+            ->bind(':userId', $user->id, ParameterType::INTEGER);
+
+        $items = $db->setQuery($query)->loadObjectList();
+
+        if ($items !== []) {
+            $domain = $this->createDomain('cwmconnect_member', 'plg_privacy_cwmconnect_member_data');
+
+            foreach ($items as $item) {
+                $domain->addItem($this->createItemFromArray((array) $item));
+            }
+
+            $domains[] = $domain;
+            $domains[] = $this->createCustomFieldsDomain('com_cwmconnect.member', $items);
+        }
+
+        $tokenQuery = $db->createQuery()
+            ->select([
+                $db->quoteName('id'),
+                $db->quoteName('label'),
+                $db->quoteName('created_at'),
+                $db->quoteName('last_used_at'),
+                $db->quoteName('revoked_at'),
+            ])
+            ->from($db->quoteName('#__cwmconnect_feed_tokens'))
+            ->where($db->quoteName('user_id') . ' = :userId')
+            ->bind(':userId', $user->id, ParameterType::INTEGER);
+
+        $tokens = $db->setQuery($tokenQuery)->loadObjectList();
+
+        if ($tokens !== []) {
+            $tokenDomain = $this->createDomain('cwmconnect_feed_tokens', 'plg_privacy_cwmconnect_feed_token_data');
+
+            foreach ($tokens as $token) {
+                $tokenDomain->addItem($this->createItemFromArray((array) $token));
+            }
+
+            $domains[] = $tokenDomain;
+        }
+
+        if ($domains !== []) {
+            $event->addResult($domains);
+        }
+    }
+
+    /**
+     * Pseudonymise member data and revoke feed tokens for a removal request.
+     *
+     * Member rows are not deleted — they're pseudonymised (personal fields
+     * cleared, display_in_directory set to 0) so the directory structure
+     * stays intact. Feed tokens are revoked (not deleted) for audit trail.
+     *
+     * @param   RemoveDataEvent  $event  The removal request event.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function onPrivacyRemoveData(RemoveDataEvent $event): void
+    {
+        $user = $event->getUser();
+
+        if (!$user) {
+            return;
+        }
+
+        $db  = $this->getDatabase();
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+        $query = $db->createQuery()
+            ->update($db->quoteName('#__cwmconnect_details'))
+            ->set($db->quoteName('name') . ' = ' . $db->quote('Removed'))
+            ->set($db->quoteName('lname') . ' = ' . $db->quote(''))
+            ->set($db->quoteName('surname') . ' = ' . $db->quote(''))
+            ->set($db->quoteName('email_to') . ' = NULL')
+            ->set($db->quoteName('telephone') . ' = NULL')
+            ->set($db->quoteName('mobile') . ' = NULL')
+            ->set($db->quoteName('fax') . ' = NULL')
+            ->set($db->quoteName('address') . ' = NULL')
+            ->set($db->quoteName('suburb') . ' = NULL')
+            ->set($db->quoteName('state') . ' = NULL')
+            ->set($db->quoteName('postcode') . ' = NULL')
+            ->set($db->quoteName('country') . ' = NULL')
+            ->set($db->quoteName('webpage') . ' = NULL')
+            ->set($db->quoteName('misc') . ' = NULL')
+            ->set($db->quoteName('image') . ' = NULL')
+            ->set($db->quoteName('birthdate') . ' = NULL')
+            ->set($db->quoteName('anniversary') . ' = NULL')
+            ->set($db->quoteName('display_in_directory') . ' = 0')
+            ->set($db->quoteName('published') . ' = 0')
+            ->set($db->quoteName('user_id') . ' = NULL')
+            ->where($db->quoteName('user_id') . ' = :userId')
+            ->bind(':userId', $user->id, ParameterType::INTEGER);
+
+        $db->setQuery($query)->execute();
+
+        $revokeQuery = $db->createQuery()
+            ->update($db->quoteName('#__cwmconnect_feed_tokens'))
+            ->set($db->quoteName('revoked_at') . ' = :now')
+            ->where($db->quoteName('user_id') . ' = :userId')
+            ->where($db->quoteName('revoked_at') . ' IS NULL')
+            ->bind(':now', $now, ParameterType::STRING)
+            ->bind(':userId', $user->id, ParameterType::INTEGER);
+
+        $db->setQuery($revokeQuery)->execute();
+    }
+}


### PR DESCRIPTION
## Summary
- New `plg_privacy_cwmconnect` plugin integrating with Joomla's `com_privacy` system
- Follows the exact same pattern as `plg_privacy_contact` in Joomla core (extends `PrivacyPlugin`, implements `SubscriberInterface`)
- **Export** (`onPrivacyExportRequest`): collects member data (via `user_id` FK) + custom fields + feed tokens for the requesting user
- **Remove** (`onPrivacyRemoveData`): pseudonymises member rows (clears name, contact, address, dates, image; sets `display_in_directory=0`, `published=0`, `user_id=NULL`) and revokes all feed tokens. Rows are kept for directory structure — not deleted
- Registered in `pkg_cwmconnect.xml`, `cwm-build.config.json`, `composer.json` PSR-4

## New files (7)
- `plugins/privacy/cwmconnect/cwmconnect.xml` — manifest
- `plugins/privacy/cwmconnect/services/provider.php` — J6.1+ single-arg constructor, `setDatabase()` injection
- `plugins/privacy/cwmconnect/src/Extension/Cwmconnect.php` — export + removal handlers
- `plugins/privacy/cwmconnect/language/en-GB/plg_privacy_cwmconnect.{ini,sys.ini}` — 4 language keys

## Test plan
- [ ] 120 tests pass (264 assertions)
- [ ] `php-cs-fixer --dry-run` clean
- [ ] Privacy → Create Export Request → includes CWM Connect member data domain
- [ ] Privacy → Remove Data Request → member row pseudonymised, feed tokens revoked
- [ ] Token hashes are NOT included in export (only label, dates, status)
- [ ] Unpaired members (no user_id) are unaffected by privacy requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)