### PR TITLE
Fix member profile page: 403 on uncategorised members + removed J3 form behaviors

### DIFF
--- a/site/src/View/Member/HtmlView.php
+++ b/site/src/View/Member/HtmlView.php
@@ -141,7 +141,13 @@ class HtmlView extends BaseHtmlView
 
         $groups = $user ? $user->getAuthorisedViewLevels() : [1];
 
-        if (!\in_array($item->access, $groups, false) || !\in_array($item->category_access, $groups, false)) {
+        // The category access check only applies to categorised members. PC-
+        // synced members carry catid=0 (no Joomla category), so the LEFT join
+        // leaves category_access NULL — that must not deny access; only the
+        // member's own access level gates an uncategorised row.
+        $categoryDenied = (int) $item->catid > 0 && !\in_array($item->category_access, $groups, false);
+
+        if (!\in_array($item->access, $groups, false) || $categoryDenied) {
             $app->enqueueMessage(Text::_('JERROR_ALERTNOAUTHOR'), 'warning');
             $app->setHeader('status', 403, true);
             throw new GenericDataException(Text::_('JERROR_ALERTNOAUTHOR'), 403);

--- a/site/tmpl/member/default_form.php
+++ b/site/tmpl/member/default_form.php
@@ -19,9 +19,11 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
-HTMLHelper::_('behavior.keepalive');
-HTMLHelper::_('behavior.formvalidation');
-HTMLHelper::_('behavior.tooltip');
+// J5/J6: behavior.formvalidation + behavior.tooltip were removed. Load the
+// form-validate + keepalive web assets and Bootstrap tooltips instead.
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('keepalive')->useScript('form.validate');
+HTMLHelper::_('bootstrap.tooltip', '.hasTooltip');
 if (isset($this->error)) : ?>
 <div class="cwmconnect-error">
 	<?php echo $this->error; ?>


### PR DESCRIPTION
Live-testing fixes that unblock the member profile page (each surfaced after the previous was fixed):

1. **403 on every PC-synced member** — the profile view required the viewer's levels to include both the member's access AND the category's access. PC-synced members carry `catid=0`, so the LEFT join leaves `category_access` NULL → `in_array(NULL, $groups)` is false → 403. Now the category access check only applies when the member actually has a category (`catid > 0`); uncategorised rows are gated by their own access alone. Mirrors the `catid==0` handling already in `MemberModel`.

2. **500 "behavior::formvalidation not found"** — `site/tmpl/member/default_form.php` (the "email this member" contact form) still called the J3 helpers `behavior.formvalidation` + `behavior.tooltip`, both removed in Joomla 4+. Replaced with the `keepalive` + `form.validate` web assets (WebAssetManager) and Bootstrap tooltips.

148/164 tests green, php-cs-fixer clean. Verified against the live dev DB (all 531 synced members are `access=1`/`catid=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)