### PR TITLE
Site UI modernization Phase 0+1: BS5 layout foundation + modern member profile

### DIFF
--- a/docs/site-modernization-plan.md
+++ b/docs/site-modernization-plan.md
@@ -1,0 +1,80 @@
+# Site-side UI modernization plan
+
+Goal: a cohesive, modern, responsive **Bootstrap 5** look across every front-end
+(site) view, replacing the remaining Joomla-3 markup and unifying the
+already-ported views under one design language. Built as a **shared design
+system** so pages stay consistent and we don't hand-roll 24 templates.
+
+## Current state (audit 2026-06-02)
+
+Nine site views / ~24 templates. Legacy (BS2 `span*`/`pull-*`, `img-polaroid`,
+`dl-horizontal`, `data-toggle`, removed `behavior.*`) is concentrated in:
+
+| View | State | Work |
+|------|-------|------|
+| **member** (profile) + sub-tmpl (address, household, form, links, articles, profile) | Heavy J3 | **Rewrite** |
+| **home** | Partly J3 (BS2 spans, polaroid) | **Rewrite** |
+| members (browse) | BS5 (recent) | Polish for consistency |
+| households | BS5 (recent) | Polish |
+| categories / category (+ items, teamleaders, children, birthann) | BS5-ish | Polish |
+| featured (+ items) | BS5-ish | Polish |
+| directory (home, search) | BS5-ish | Polish |
+| myprofile (+ placeholder) | BS5 (Phase H) | Polish |
+| members/default_pdf, *KmlView/Vcf | non-HTML output | leave |
+
+## Phase 0 — Design foundation (do first)
+
+Reusable Joomla layouts under `site/layouts/cwmconnect/` so every view composes
+the same building blocks:
+
+- `photo.php` — responsive member/household `<img>` (thumb/medium srcset, WebP via
+  proxy, lazy, click-to-full). Replaces the inline `<img>` repeated in 6 templates.
+- `membercard.php` — directory card (photo + name + position + household chip).
+- `pageheader.php` — page title + breadcrumb/back link + optional search slot.
+- `sectioncard.php` — BS5 card with header (icon + title) + body slot.
+- `emptystate.php` — consistent "nothing here" / CTA block.
+
+Plus a small **`media/com_cwmconnect/css/cwmconnect.es6`** (built via the rollup
+pipeline → `media/.../css`) for design tokens + a few component tweaks (card
+hover, avatar ring, position chips). Keep it thin — lean on BS5 utilities.
+
+Design language: BS5 cards, `row g-3` grids, `badge`/`btn`/`list-group`,
+`icon-*` glyphs, `rounded`/`object-fit-cover` avatars, generous spacing,
+mobile-first (`col-12 col-md-* col-lg-*`), dark-mode-safe (BS5 classes, no
+hard-coded colours), a11y (alt text, heading order, aria).
+
+## Phase 1 — Member profile (highest impact)
+
+Hero header (photo + name + position/category/household + Email/vCard buttons)
+over stacked **section cards** (Contact, Household w/ member thumbnails, Links,
+Other info, Articles, Joomla profile, Email-this-member form). Single scrolling
+page — drop `presentation_style` tabs/sliders/plain. Rewrite default.php + all 6
+sub-templates onto the Phase 0 partials. (Detailed in the member-profile spec.)
+
+## Phase 2 — Home / directory landing
+
+Rebuild home/default.php on BS5: hero/intro, prominent "Browse directory" CTA,
+search, and (when present) a featured-members grid using `membercard`. Fixes the
+"empty when nothing featured" problem too.
+
+## Phase 3 — Consistency polish (already-BS5 views)
+
+members, households, categories, category, featured, directory, myprofile:
+swap bespoke card markup for the shared `membercard`/`sectioncard`/`photo`
+partials, align spacing/typography, unify empty states and the photo `srcset`.
+Mostly mechanical; big consistency payoff.
+
+## Order & sizing
+
+0 (foundation) → 1 (member, biggest win + worst legacy) → 2 (home) → 3 (polish).
+Phases 0–2 are the substantive build; phase 3 is incremental per view. Each phase
+is its own PR (master needs **squash** merges — signed-commit rule).
+
+## Out of scope / dependencies
+
+- `presentation_style` config param becomes unused (prune from config.xml later).
+- Category breadcrumbs depend on the **category-system review** (synced members
+  have catid=0) — degrade gracefully meanwhile.
+- AVIF photo format still deferred (no encoder); WebP/JPEG only.
+
+Related: [[project-photo-subsystem]], [[project-category-system-review]].

--- a/site/layouts/cwmconnect/emptystate.php
+++ b/site/layouts/cwmconnect/emptystate.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * Consistent "nothing here" block with an optional call-to-action button.
+ *
+ * @var  array  $displayData
+ *   - message  string  The empty-state message.
+ *   - icon     string  Optional icon-* class (default icon-info-circle).
+ *   - ctaUrl   string  Optional CTA button URL.
+ *   - ctaText  string  CTA button label.
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+$message = (string) ($displayData['message'] ?? '');
+$icon    = trim((string) ($displayData['icon'] ?? 'icon-info-circle'));
+$ctaUrl  = trim((string) ($displayData['ctaUrl'] ?? ''));
+$ctaText = (string) ($displayData['ctaText'] ?? '');
+?>
+<div class="cwm-empty-state text-center text-body-secondary py-5">
+    <?php if ($icon !== '') : ?>
+        <div class="display-6 mb-2"><span class="<?php echo htmlspecialchars($icon, ENT_QUOTES); ?>" aria-hidden="true"></span></div>
+    <?php endif; ?>
+    <p class="mb-3"><?php echo htmlspecialchars($message, ENT_QUOTES); ?></p>
+    <?php if ($ctaUrl !== '' && $ctaText !== '') : ?>
+        <a class="btn btn-primary" href="<?php echo htmlspecialchars($ctaUrl, ENT_QUOTES); ?>">
+            <?php echo htmlspecialchars($ctaText, ENT_QUOTES); ?>
+        </a>
+    <?php endif; ?>
+</div>

--- a/site/layouts/cwmconnect/membercard.php
+++ b/site/layouts/cwmconnect/membercard.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * Directory member card: photo + name + optional position + household chip,
+ * the whole card linking to the member's profile. Used by every member grid.
+ *
+ * @var  array  $displayData
+ *   - id          int     Member id.
+ *   - name        string  Display name.
+ *   - hasPhoto    bool    Whether the member has a photo.
+ *   - profileUrl  string  Link to the profile.
+ *   - position    string  Pre-rendered position name(s), or ''.
+ *   - household   string  Household name chip, or ''.
+ */
+
+use CWM\Component\Cwmconnect\Site\Helper\Layout;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+$id         = (int) ($displayData['id'] ?? 0);
+$name       = (string) ($displayData['name'] ?? '');
+$hasPhoto   = (bool) ($displayData['hasPhoto'] ?? false);
+$profileUrl = (string) ($displayData['profileUrl'] ?? '');
+$position   = trim((string) ($displayData['position'] ?? ''));
+$household  = trim((string) ($displayData['household'] ?? ''));
+?>
+<a class="card h-100 text-decoration-none text-body shadow-sm cwm-member-card" href="<?php echo htmlspecialchars($profileUrl, ENT_QUOTES); ?>">
+    <?php
+    echo Layout::render('photo', [
+        'id'       => $id,
+        'hasPhoto' => $hasPhoto,
+        'alt'      => $name,
+        'class'    => 'card-img-top',
+        'sizes'    => '(max-width: 600px) 50vw, 300px',
+    ]);
+?>
+    <div class="card-body p-2 text-center">
+        <div class="fw-semibold text-truncate"><?php echo htmlspecialchars($name, ENT_QUOTES); ?></div>
+        <?php if ($position !== '') : ?>
+            <div class="small text-body-secondary text-truncate"><?php echo htmlspecialchars($position, ENT_QUOTES); ?></div>
+        <?php endif; ?>
+        <?php if ($household !== '') : ?>
+            <div class="mt-1"><span class="badge rounded-pill bg-body-secondary text-body-secondary"><?php echo htmlspecialchars($household, ENT_QUOTES); ?></span></div>
+        <?php endif; ?>
+    </div>
+</a>

--- a/site/layouts/cwmconnect/pageheader.php
+++ b/site/layouts/cwmconnect/pageheader.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * Consistent page header: an optional back link, the page title, and an
+ * optional subtitle (pre-rendered HTML, e.g. breadcrumb chips or a count).
+ *
+ * @var  array  $displayData
+ *   - title     string  Page title.
+ *   - backUrl   string  Optional "back" link URL.
+ *   - backText  string  Back link label.
+ *   - subtitle  string  Optional pre-rendered HTML under the title.
+ *   - badge     string  Optional pre-rendered badge HTML next to the title.
+ */
+
+use Joomla\CMS\Language\Text;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+$title    = (string) ($displayData['title'] ?? '');
+$backUrl  = trim((string) ($displayData['backUrl'] ?? ''));
+$backText = (string) ($displayData['backText'] ?? Text::_('COM_CWMCONNECT_HOME_BROWSE_DIRECTORY'));
+$subtitle = (string) ($displayData['subtitle'] ?? '');
+$badge    = (string) ($displayData['badge'] ?? '');
+?>
+<div class="cwm-page-header mb-3">
+    <?php if ($backUrl !== '') : ?>
+        <a class="small text-decoration-none d-inline-block mb-2" href="<?php echo htmlspecialchars($backUrl, ENT_QUOTES); ?>">
+            <span class="icon-arrow-left" aria-hidden="true"></span> <?php echo htmlspecialchars($backText, ENT_QUOTES); ?>
+        </a>
+    <?php endif; ?>
+    <h1 class="h2 mb-1">
+        <?php echo htmlspecialchars($title, ENT_QUOTES); ?>
+        <?php echo $badge; ?>
+    </h1>
+    <?php if ($subtitle !== '') : ?>
+        <div class="text-body-secondary"><?php echo $subtitle; ?></div>
+    <?php endif; ?>
+</div>

--- a/site/layouts/cwmconnect/photo.php
+++ b/site/layouts/cwmconnect/photo.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * Responsive, optimized member or household photo. The proxy serves WebP/JPEG
+ * per the request's Accept header; we offer thumb/medium via srcset and lazy-
+ * load. Falls back to a neutral avatar placeholder when there is no photo.
+ *
+ * @var  array  $displayData
+ *   - id        int     Member id or family-unit id.
+ *   - type      string  'member' (default) | 'household'.
+ *   - size      string  'thumb' (default) | 'medium' — the base src.
+ *   - hasPhoto  bool    Whether a real photo exists (default true).
+ *   - alt       string  Alt text.
+ *   - class     string  Extra <img> classes.
+ *   - sizes     string  The `sizes` attribute (default card-friendly).
+ *   - width     int     (default 300)  height int (default 400).
+ *   - linkFull  bool    Wrap in a link to the full-resolution original.
+ *   - rounded   bool    Apply rounded + object-fit-cover avatar styling.
+ */
+
+use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+$id       = (int) ($displayData['id'] ?? 0);
+$type     = ($displayData['type'] ?? 'member') === 'household' ? 'household' : 'member';
+$size     = ($displayData['size'] ?? 'thumb') === 'medium' ? 'medium' : 'thumb';
+$hasPhoto = (bool) ($displayData['hasPhoto'] ?? true);
+$alt      = (string) ($displayData['alt'] ?? '');
+$class    = trim((string) ($displayData['class'] ?? ''));
+$sizes    = (string) ($displayData['sizes'] ?? '(max-width: 600px) 50vw, 300px');
+$width    = (int) ($displayData['width'] ?? 300);
+$height   = (int) ($displayData['height'] ?? 400);
+$linkFull = (bool) ($displayData['linkFull'] ?? false);
+$rounded  = (bool) ($displayData['rounded'] ?? false);
+
+if ($rounded) {
+    $class = trim($class . ' rounded object-fit-cover');
+}
+
+if (!$hasPhoto || $id <= 0) {
+    $boxStyle = $rounded ? 'width:' . $width . 'px;height:' . $width . 'px;' : 'aspect-ratio:3/4;';
+    echo '<span class="cwm-photo-placeholder d-inline-flex align-items-center justify-content-center bg-body-secondary text-body-tertiary ' . htmlspecialchars($class, ENT_QUOTES) . '"'
+        . ' style="' . $boxStyle . '" role="img" aria-label="' . htmlspecialchars($alt !== '' ? $alt : Text::_('COM_CWMCONNECT_IMAGE_DETAILS'), ENT_QUOTES) . '">'
+        . '<span class="icon-user" aria-hidden="true"></span></span>';
+
+    return;
+}
+
+$route  = $type === 'household' ? [RouteHelper::class, 'getHouseholdPhotoRoute'] : [RouteHelper::class, 'getPhotoRoute'];
+$srcset = $type === 'household'
+    ? RouteHelper::getHouseholdPhotoSrcset($id)
+    : RouteHelper::getPhotoSrcset($id);
+
+$src     = Route::_($route($id, $size));
+$fullUrl = Route::_($route($id));
+
+$img = '<img src="' . htmlspecialchars($src, ENT_QUOTES) . '"'
+    . ' srcset="' . htmlspecialchars($srcset, ENT_QUOTES) . '"'
+    . ' sizes="' . htmlspecialchars($sizes, ENT_QUOTES) . '"'
+    . ' width="' . $width . '" height="' . $height . '" loading="lazy" decoding="async"'
+    . ($class !== '' ? ' class="' . htmlspecialchars($class, ENT_QUOTES) . '"' : '')
+    . ' alt="' . htmlspecialchars($alt, ENT_QUOTES) . '">';
+
+if ($linkFull) {
+    echo '<a href="' . htmlspecialchars($fullUrl, ENT_QUOTES) . '" target="_blank" rel="noopener"'
+        . ' title="' . htmlspecialchars(Text::_('COM_CWMCONNECT_IMAGE_VIEW_FULL'), ENT_QUOTES) . '">' . $img . '</a>';
+
+    return;
+}
+
+echo $img;

--- a/site/layouts/cwmconnect/sectioncard.php
+++ b/site/layouts/cwmconnect/sectioncard.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * Bootstrap 5 section card: a titled card (optional icon) wrapping pre-rendered
+ * body HTML. Used to lay directory sections out consistently.
+ *
+ * @var  array  $displayData
+ *   - title  string  Card header title.
+ *   - icon   string  Optional icon-* class (e.g. 'icon-envelope').
+ *   - body   string  Pre-rendered HTML for the card body.
+ *   - class  string  Extra classes on the .card wrapper.
+ *   - id     string  Optional element id (anchor target).
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+$title = (string) ($displayData['title'] ?? '');
+$icon  = trim((string) ($displayData['icon'] ?? ''));
+$body  = (string) ($displayData['body'] ?? '');
+$class = trim((string) ($displayData['class'] ?? ''));
+$id    = trim((string) ($displayData['id'] ?? ''));
+?>
+<div class="card shadow-sm h-100 <?php echo htmlspecialchars($class, ENT_QUOTES); ?>"<?php echo $id !== '' ? ' id="' . htmlspecialchars($id, ENT_QUOTES) . '"' : ''; ?>>
+    <?php if ($title !== '') : ?>
+        <div class="card-header bg-transparent fw-semibold">
+            <?php if ($icon !== '') : ?><span class="<?php echo htmlspecialchars($icon, ENT_QUOTES); ?> me-2 text-primary" aria-hidden="true"></span><?php endif; ?>
+            <?php echo htmlspecialchars($title, ENT_QUOTES); ?>
+        </div>
+    <?php endif; ?>
+    <div class="card-body">
+        <?php echo $body; ?>
+    </div>
+</div>

--- a/site/src/Helper/Layout.php
+++ b/site/src/Helper/Layout.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Site\Helper;
+
+use Joomla\CMS\Layout\LayoutHelper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Thin wrapper for the component's shared front-end layout partials under
+ * `components/com_cwmconnect/layouts/cwmconnect/`. Lets every template compose
+ * the same Bootstrap 5 building blocks (photo, member card, section card,
+ * page header, empty state) without repeating the LayoutHelper base path.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class Layout
+{
+    /**
+     * Render a `cwmconnect.*` layout partial.
+     *
+     * @param   string                $name  Partial name (e.g. 'photo', 'membercard').
+     * @param   array<string, mixed>  $data  Layout data.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function render(string $name, array $data = []): string
+    {
+        return LayoutHelper::render(
+            'cwmconnect.' . $name,
+            $data,
+            JPATH_ROOT . '/components/com_cwmconnect/layouts',
+        );
+    }
+}

--- a/site/tmpl/member/default.php
+++ b/site/tmpl/member/default.php
@@ -4,372 +4,178 @@
  * @package    Cwmconnect.Site
  * @copyright  (C) 2026 CWM Team All rights reserved
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
  */
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Cwmconnect\Site\Helper\Layout;
 use CWM\Component\Cwmconnect\Site\Helper\RenderHelper;
 use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
-use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Uri\Uri;
 
-$cparams = ComponentHelper::getParams('com_media');
-/** @var \Joomla\Registry\Registry $tparams */
-$tparams = $this->params;
-$app = Factory::getApplication();
-$menu = $app->getMenu()->getActive()->id;
-$renderHelper = new RenderHelper();
-$presentation_style = $tparams->get('presentation_style');
+/** @var \CWM\Component\Cwmconnect\Site\View\Member\HtmlView $this */
+
+$member       = $this->member;
+$params       = $this->params;
+$render       = new RenderHelper();
+$hasPhoto     = !empty($member->image) && $params->get('show_image');
+$position     = $member->con_position && $params->get('show_position')
+    ? $render->getPosition($member->con_position) : '';
+$familyPos    = $member->attribs->get('familypostion');
+$spouse       = $familyPos != '2' ? $render->getSpouse((int) $member->fu_id, (int) $familyPos) : '';
+$children     = ($params->get('dr_show_children') && $familyPos != '2')
+    ? $render->getChildren((int) $member->fu_id, false, $member->children) : '';
+$categoryUrl  = (int) $member->catid > 0 ? RouteHelper::getCategoryRoute($member->catid) : '';
+$hasEmailForm = $params->get('show_email_form') && !empty($member->email_to);
 ?>
-<div class="contact<?php echo $this->pageclass_sfx ?>">
-	<?php if ($this->params->get('show_page_heading')) {
-	    ?>
-		<h1>
-			<?php echo $this->escape($this->params->get('page_heading')); ?>
-		</h1>
-		<?php
-	}
+<div class="cwmconnect-member container-fluid px-0">
 
-if ($this->member->name && $this->params->get('show_name')) {
+    <?php // Hero header?>
+    <div class="card shadow-sm mb-4 cwm-member-hero">
+        <div class="card-body">
+            <a class="small text-decoration-none d-inline-block mb-3" href="<?php echo Route::_('index.php?option=com_cwmconnect&view=members'); ?>">
+                <span class="icon-arrow-left" aria-hidden="true"></span> <?php echo Text::_('COM_CWMCONNECT_HOME_BROWSE_DIRECTORY'); ?>
+            </a>
+
+            <div class="row g-4 align-items-center">
+                <?php if ($hasPhoto) : ?>
+                    <div class="col-12 col-md-auto text-center">
+                        <?php echo Layout::render('photo', [
+                            'id'       => (int) $member->id,
+                            'size'     => 'medium',
+                            'hasPhoto' => true,
+                            'alt'      => $member->name,
+                            'class'    => 'rounded shadow-sm',
+                            'sizes'    => '200px',
+                            'width'    => 200,
+                            'height'   => 267,
+                            'linkFull' => true,
+                        ]); ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="col">
+                    <?php if ($params->get('show_name')) : ?>
+                        <h1 class="h2 mb-1">
+                            <?php echo $this->escape($member->name); ?>
+                            <?php if ((int) $this->item->published === 0) : ?>
+                                <span class="badge bg-warning text-dark align-middle"><?php echo Text::_('JUNPUBLISHED'); ?></span>
+                            <?php endif; ?>
+                        </h1>
+                    <?php endif; ?>
+
+                    <div class="d-flex flex-wrap gap-2 mb-2">
+                        <?php if ($position !== '') : ?>
+                            <span class="badge rounded-pill bg-primary-subtle text-primary-emphasis"><?php echo $this->escape($position); ?></span>
+                        <?php endif; ?>
+                        <?php if ($member->category_title && $params->get('show_contact_category') && (int) $member->catid > 0) : ?>
+                            <a class="badge rounded-pill bg-body-secondary text-body-secondary text-decoration-none" href="<?php echo $categoryUrl; ?>">
+                                <?php echo $this->escape($member->category_title); ?>
+                            </a>
+                        <?php endif; ?>
+                        <?php if (!empty($member->fu_name)) : ?>
+                            <span class="badge rounded-pill bg-body-secondary text-body-secondary">
+                                <span class="icon-users" aria-hidden="true"></span> <?php echo $this->escape($member->fu_name); ?>
+                            </span>
+                        <?php endif; ?>
+                    </div>
+
+                    <?php if ($spouse) : ?>
+                        <div class="text-body-secondary"><strong><?php echo Text::_('COM_CWMCONNECT_SPOUSE'); ?>:</strong> <?php echo $spouse; ?></div>
+                    <?php endif; ?>
+                    <?php if ($children) : ?>
+                        <div class="text-body-secondary"><?php echo $children; ?></div>
+                    <?php endif; ?>
+
+                    <div class="d-flex flex-wrap gap-2 mt-3">
+                        <?php if ($hasEmailForm) : ?>
+                            <a class="btn btn-primary btn-sm" href="#cwm-email-form">
+                                <span class="icon-envelope" aria-hidden="true"></span> <?php echo Text::_('COM_CWMCONNECT_EMAIL_FORM'); ?>
+                            </a>
+                        <?php endif; ?>
+                        <?php if ($params->get('allow_vcard')) : ?>
+                            <a class="btn btn-outline-secondary btn-sm" href="<?php echo Route::_('index.php?option=com_cwmconnect&view=member&id=' . (int) $member->id . '&format=vcf'); ?>">
+                                <span class="icon-vcard" aria-hidden="true"></span> <?php echo Text::_('COM_CWMCONNECT_VCARD'); ?>
+                            </a>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // Section cards?>
+    <div class="row g-3">
+        <?php
+        $contact = trim($this->loadTemplate('address'));
+if ($contact !== '') :
     ?>
-		<div class="page-header">
-			<h2>
-				<?php if ($this->item->published == 0) {
-				    ?>
-					<span class="label label-warning"><?php echo Text::_('JUNPUBLISHED'); ?></span>
-					<?php
-				} ?>
-				<span class="contact-name"><?php echo $this->member->name; ?></span>
-			</h2>
-			<p><a href="<?php echo Route::_('index.php?option=com_cwmconnect&view=home'); ?>">Members Home -></a>
-				<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($this->item->catid));
-    ?>"><?php echo Text::_($this->item->category_title); ?>
-					-></a>
-				<span class="contact-name"><?php echo $this->member->name; ?></span></p>
-		</div>
-		<?php
-}
+            <div class="col-12 col-lg-6">
+                <?php echo Layout::render('sectioncard', [
+            'title' => Text::_('COM_CWMCONNECT_DETAILS'),
+            'icon'  => 'icon-address',
+            'body'  => $contact,
+        ]); ?>
+            </div>
+        <?php endif; ?>
 
-$spouse = $renderHelper->getSpouse((int) $this->member->fu_id, (int) $this->member->attribs->get('familypostion'));
-
-if ($spouse && $this->member->attribs->get('familypostion') != '2') {
+        <?php
+        $household = trim($this->loadTemplate('household'));
+if ($household !== '') :
     ?>
-		<p>
-			<?php echo '<span class="jicons-text">' . Text::_('COM_CWMCONNECT_SPOUSE') . ': </span>' . $spouse; ?>
-		</p>
-		<?php
-} ?>
-	<?php if ($this->params->get('dr_show_children') && $this->member->attribs->get('familypostion') != '2') {
-	    $children = $renderHelper->getChildren((int) $this->member->fu_id, false, $this->member->children);
-	    ?>
-		<p>
-			<?php
-	        if ($children) {
-	            echo $children . '<br />';
-	        } ?>
-		</p>
-	<?php } ?>
-	<?php if ($this->params->get('show_contact_category') == 'show_no_link') {
-	    ?>
-		<h3>
-			<span class="contact-category"><?php echo $this->member->category_title; ?></span>
-		</h3>
-	<?php } ?>
-	<?php if ($this->params->get('show_contact_category') == 'show_with_link') {
-	    ?>
-		<?php $contactLink = RouteHelper::getCategoryRoute($this->member->catid); ?>
-		<h3>
-			<span class="contact-category"><a href="<?php echo $contactLink; ?>">
-					<?php echo $this->escape($this->member->category_title); ?></a>
-			</span>
-		</h3>
-	<?php } ?>
-	<?php if ($this->params->get('show_contact_list') && count($this->contacts) > 1) {
-	    ?>
-		<form action="#" method="get" name="selectForm" id="selectForm">
-			<?php echo Text::_('COM_CWMCONNECT_SELECT_CHURCHDIRECTORY'); ?>
-			<?php echo HTMLHelper::_('select.genericlist', $this->contacts, 'id', 'class="inputbox" onchange="document.location.href = this.value"', 'link', 'name', $this->member->link); ?>
-		</form>
-	<?php } ?>
+            <div class="col-12 col-lg-6">
+                <?php echo Layout::render('sectioncard', [
+            'title' => Text::_('COM_CWMCONNECT_MEMBER_HOUSEHOLD_HEADING'),
+            'icon'  => 'icon-users',
+            'body'  => $household,
+        ]); ?>
+            </div>
+        <?php endif; ?>
 
-	<?php if ($presentation_style == 'tabs') {
-	    ?>
-		<ul class="nav nav-tabs" id="myTab">
-			<li><a data-toggle="tab" href="#basic-details"><?php echo Text::_('COM_CWMCONNECT_DETAILS'); ?></a>
-			</li>
+        <?php if ($member->misc && $params->get('show_misc')) : ?>
+            <div class="col-12 col-lg-6">
+                <?php echo Layout::render('sectioncard', [
+            'title' => Text::_('COM_CWMCONNECT_OTHER_INFORMATION'),
+            'icon'  => 'icon-info-circle',
+            'body'  => '<div class="contact-misc">' . $member->misc . '</div>',
+        ]); ?>
+            </div>
+        <?php endif; ?>
 
-			<?php if ($this->params->get('show_email_form') && ($this->member->email_to || $this->member->user_id)) {
-			    ?>
-				<li><a data-toggle="tab"
-				       href="#display-form"><?php echo Text::_('COM_CWMCONNECT_EMAIL_FORM'); ?></a>
-				</li>
-				<?php
-			}
-	    if ($this->params->get('show_links')) {
-	        ?>
-				<li><a data-toggle="tab" href="#display-links"><?php echo Text::_('COM_CWMCONNECT_LINKS'); ?></a>
-				</li>
-				<?php
-	    }
-	    if ($this->params->get('show_articles') && $this->member->user_id && $this->member->articles) {
-	        ?>
-				<li><a data-toggle="tab" href="#display-articles"><?php echo Text::_('JGLOBAL_ARTICLES'); ?></a>
-				</li>
-				<?php
-	    }
-	    if ($this->params->get('show_profile') && $this->member->user_id && JPluginHelper::isEnabled('user', 'profile')) {
-	        ?>
-				<li><a data-toggle="tab"
-				       href="#display-profile"><?php echo Text::_('COM_CWMCONNECT_PROFILE'); ?></a>
-				</li>
-				<?php
-	    }
-	    if ($this->member->misc && $this->params->get('show_misc')) {
-	        ?>
-				<li><a data-toggle="tab"
-				       href="#display-misc"><?php echo Text::_('COM_CWMCONNECT_OTHER_INFORMATION'); ?></a>
-				</li>
-				<?php
-	    }
-	    ?>
-		</ul>
-		<?php
-	}
-?>
-	<?php if ($presentation_style == 'sliders') {
-	    ?>
-		<?php echo HTMLHelper::_('bootstrap.startAccordion', 'slide-contact', ['active' => 'basic-details']); ?>
-	<?php } ?>
-	<?php if ($presentation_style == 'tabs') {
-	    ?>
-		<?php echo HTMLHelper::_('bootstrap.startPane', 'myTab', ['active' => 'basic-details']); ?>
-	<?php } ?>
+        <?php if ($params->get('show_links') && $member->params->get('linka') != null) : ?>
+            <div class="col-12 col-lg-6">
+                <?php echo Layout::render('sectioncard', [
+            'title' => Text::_('COM_CWMCONNECT_LINKS'),
+            'icon'  => 'icon-link',
+            'body'  => trim($this->loadTemplate('links')),
+        ]); ?>
+            </div>
+        <?php endif; ?>
 
-	<?php if ($presentation_style == 'sliders') {
-	    ?>
-		<?php echo HTMLHelper::_('bootstrap.addSlide', 'slide-contact', Text::_('COM_CWMCONNECT_DETAILS'), 'basic-details'); ?>
-	<?php } ?>
-	<?php if ($presentation_style == 'tabs') {
-	    ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'basic-details', Text::_('COM_CWMCONNECT_DETAILS', true)); ?>
-	<?php } ?>
-	<?php if ($presentation_style == 'plain') {
-	    ?>
-		<?php echo '<h3>' . Text::_('COM_CWMCONNECT_DETAILS') . '</h3>'; ?>
-	<?php } ?>
+        <?php if ($params->get('show_articles') && $member->user_id && $member->articles) : ?>
+            <div class="col-12 col-lg-6">
+                <?php echo Layout::render('sectioncard', [
+            'title' => Text::_('JGLOBAL_ARTICLES'),
+            'icon'  => 'icon-file-alt',
+            'body'  => trim($this->loadTemplate('articles')),
+        ]); ?>
+            </div>
+        <?php endif; ?>
 
-	<div class="row" style="padding-left: 20px;">
-		<?php
-	    if ($this->member->con_position && $this->params->get('show_position')) {
-	        ?>
-			<div class="span6">
-				<span class="span4 jicons-text">
-						<?php if ($this->member->con_position != '-1') {
-						    echo Text::_('COM_CWMCONNECT_POSITIONS') . ':';
-						}
-	        ?>
-				</span>
-				<span class="span8">
-					<?php echo $renderHelper->getPosition($this->member->con_position); ?>
-				</span>
-			</div>
-			<?php
-	    }
+        <?php if ($hasEmailForm) : ?>
+            <div class="col-12" id="cwm-email-form">
+                <?php echo Layout::render('sectioncard', [
+            'title' => Text::_('COM_CWMCONNECT_EMAIL_FORM'),
+            'icon'  => 'icon-envelope',
+            'body'  => trim($this->loadTemplate('form')),
+        ]); ?>
+            </div>
+        <?php endif; ?>
+    </div>
 
-if (!empty($this->member->image) && $this->params->get('show_image')) {
-    ?>
-			<div class="thumbnail pull-right">
-				<a href="<?php echo $this->escape(Route::_(RouteHelper::getPhotoRoute((int) $this->member->id))); ?>"
-				   target="_blank" rel="noopener" title="<?php echo $this->escape(Text::_('COM_CWMCONNECT_IMAGE_VIEW_FULL')); ?>">
-					<img src="<?php echo $this->escape(Route::_(RouteHelper::getPhotoRoute((int) $this->member->id, 'medium'))); ?>"
-						 alt="<?php echo $this->escape(Text::_('COM_CWMCONNECT_IMAGE_DETAILS')); ?>"
-						 width="300" height="400" loading="lazy" decoding="async"
-						 class="thumbnail" style="max-width: 250px;" align="right" />
-				</a>
-			</div>
-			<?php
-}
-echo "</div>";
-echo '<div class="clearfix"></div>';
-echo $this->loadTemplate('address');
-echo $this->loadTemplate('household');
-
-if ($this->params->get('allow_vcard')) {
-    echo Text::_('COM_CWMCONNECT_DOWNLOAD_INFORMATION_AS'); ?>
-			<a href="<?php echo Route::_('index.php?option=com_cwmconnect&amp;view=member&amp;id=' . $this->member->id . '&amp;format=vcf'); ?>">
-				<?php echo Text::_('COM_CWMCONNECT_VCARD'); ?></a>
-			<?php
-}
-if ($presentation_style == 'sliders') {
-    echo HTMLHelper::_('bootstrap.endSlide');
-}
-if ($presentation_style == 'tabs') {
-    echo HTMLHelper::_('bootstrap.endTab');
-}
-if ($this->params->get('show_email_form') && !empty($this->member->email_to)) {
-    if ($presentation_style == 'sliders') {
-        echo HTMLHelper::_('bootstrap.addSlide', 'slide-contact', Text::_('COM_CWMCONNECT_EMAIL_FORM'), 'display-form');
-    }
-    if ($presentation_style == 'tabs') {
-        echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'display-form', Text::_('COM_CWMCONNECT_EMAIL_FORM', true));
-    }
-    if ($presentation_style == 'plain') {
-        ?>
-				<?php echo '<h3>' . Text::_('COM_CWMCONNECT_EMAIL_FORM') . '</h3>'; ?>
-			<?php } ?>
-
-			<?php echo $this->loadTemplate('form'); ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endSlide'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php } ?>
-
-		<?php } ?>
-
-		<?php if ($this->params->get('show_links') && $this->member->params->get('link' . 'a') != null) {
-		    ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addSlide', 'slide-links', Text::_('COM_CWMCONNECT_LINKS'), 'display-form'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'display-links', Text::_('COM_CONTACT_LINKS', true)); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'plain') {
-			    ?>
-			<?php echo '<h3>' . Text::_('COM_CWMCONNECT_LINKS') . '</h3>'; ?>
-		<?php } ?>
-
-			<?php echo $this->loadTemplate('links'); ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endSlide'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php } ?>
-		<?php } ?>
-
-		<?php if ($this->params->get('show_articles') && $this->member->user_id && $this->member->articles) {
-		    ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addSlide', 'slide-contact', Text::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'display-articles', Text::_('JGLOBAL_ARTICLES', true)); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'plain') {
-			    ?>
-			<?php echo '<h3>' . Text::_('JGLOBAL_ARTICLES') . '</h3>'; ?>
-		<?php } ?>
-
-			<?php echo $this->loadTemplate('articles'); ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endSlide'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php } ?>
-
-		<?php } ?>
-		<?php if ($this->params->get('show_profile') && $this->member->user_id && JPluginHelper::isEnabled('user', 'profile')) {
-		    ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addSlide', 'slide-contact', Text::_('COM_CWMCONNECT_PROFILE'), 'display-profile'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'display-profile', Text::_('COM_CWMCONNECT_PROFILE', true)); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'plain') {
-			    ?>
-			<?php echo '<h3>' . Text::_('COM_CWMCONNECT_PROFILE') . '</h3>'; ?>
-		<?php } ?>
-
-			<?php echo $this->loadTemplate('profile'); ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endSlide'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php } ?>
-
-		<?php } ?>
-		<?php if ($this->member->misc && $this->params->get('show_misc')) {
-		    ?>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addSlide', 'slide-contact', Text::_('COM_CWMCONNECT_OTHER_INFORMATION'), 'display-misc'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'display-misc', Text::_('COM_CWMCONNECT_OTHER_INFORMATION')); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'plain') {
-			    ?>
-			<?php echo '<h3>' . Text::_('COM_CWMCONNECT_OTHER_INFORMATION') . '</h3>'; ?>
-		<?php } ?>
-
-			<div class="contact-miscinfo">
-				<dl class="dl-horizontal">
-					<dt>
-							<span class="<?php echo $this->params->get('marker_class'); ?>">
-								<?php echo $this->params->get('marker_misc'); ?>
-							</span>
-					</dt>
-					<dd>
-							<span class="contact-misc">
-								<?php echo $this->member->misc; ?>
-							</span>
-					</dd>
-				</dl>
-			</div>
-
-			<?php if ($presentation_style == 'sliders') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endSlide'); ?>
-		<?php } ?>
-			<?php if ($presentation_style == 'tabs') {
-			    ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php } ?>
-
-		<?php } ?>
-
-		<?php if ($presentation_style == 'sliders') {
-		    ?>
-			<?php echo HTMLHelper::_('bootstrap.endAccordion'); ?>
-		<?php } ?>
-		<?php if ($presentation_style == 'tabs') {
-		    ?>
-			<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
-		<?php } ?>
-		<?php echo $this->item->event->afterDisplayContent; ?>
-	</div>
+    <?php echo $this->item->event->afterDisplayContent; ?>
+</div>

--- a/site/tmpl/member/default_address.php
+++ b/site/tmpl/member/default_address.php
@@ -4,248 +4,107 @@
  * @package    Cwmconnect.Site
  * @copyright  (C) 2026 CWM Team All rights reserved
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
  */
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
-use CWM\Component\Cwmconnect\Site\Helper\RenderHelper;
-use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
-use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Router\Route;
-use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\String\PunycodeHelper;
 
-/* marker_class: Class based on the selection of text, none, or icons
- * jicon-text, jicon-none, jicon-icon
- */
+/** @var \CWM\Component\Cwmconnect\Site\View\Member\HtmlView $this */
+
+$member = $this->member;
+$params = $this->params;
+
+// Prefer the admin-entered mailing address when "show full" is on and one
+// exists, else the physical/synced address.
+$useMailing = $params->get('dr_show_address_full') === '1'
+    && ($member->attribs->get('mailingaddress') || $member->attribs->get('mailingsuburb') || $member->attribs->get('mailingstate'));
+
+$street   = $useMailing ? $member->attribs->get('mailingaddress') : $member->address;
+$suburb   = $useMailing ? $member->attribs->get('mailingsuburb') : $member->suburb;
+$state    = $useMailing ? $member->attribs->get('mailingstate') : $member->state;
+$postcode = $useMailing ? $member->attribs->get('mailingpostcode') : $member->postcode;
+$country  = $useMailing ? $member->attribs->get('mailingcountry') : $member->country;
+
+$addressParts = [];
+
+if ($street && $params->get('show_street_address')) {
+    $addressParts[] = '<span itemprop="streetAddress">' . nl2br($this->escape($street)) . '</span>';
+}
+
+$cityLine = [];
+
+if ($suburb && $params->get('show_suburb')) {
+    $cityLine[] = '<span itemprop="addressLocality">' . $this->escape($suburb) . '</span>';
+}
+
+if ($state && $params->get('show_state')) {
+    $cityLine[] = '<span itemprop="addressRegion">' . $this->escape($state) . '</span>';
+}
+
+if ($postcode && $params->get('show_postcode')) {
+    $cityLine[] = '<span itemprop="postalCode">' . $this->escape($postcode) . '</span>';
+}
+
+if ($cityLine !== []) {
+    $addressParts[] = implode(' ', $cityLine);
+}
+
+if ($country && $params->get('show_country')) {
+    $addressParts[] = '<span itemprop="addressCountry">' . $this->escape($country) . '</span>';
+}
+
+$webHref = '';
+
+if ($member->webpage && $params->get('show_webpage')) {
+    $webHref = preg_match('~^https?://~i', $member->webpage) ? $member->webpage : 'http://' . $member->webpage;
+}
 ?>
-<dl class="contact-address dl-horizontal" itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
-	<?php if ($this->params->get('dr_show_address_full') === '1') : ?>
-		<?php if ($this->member->attribs->get('mailingaddress')
-            || $this->member->attribs->get('mailingsuburb')
-            || $this->member->attribs->get('mailingstate')
-		) :
-		    ?>
-			<?php if ($this->params->get('address_check') > 0) : ?>
-			<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-                    <?php echo $this->params->get('marker_address'); ?>
-                </span>
-			</dt>
-		<?php endif; ?>
-			<dd>
-				<?php if ($this->member->address && $this->params->get('show_street_address')) : ?>
+<ul class="list-unstyled mb-0 cwm-contact" itemscope itemtype="https://schema.org/PostalAddress">
+    <?php if ($addressParts !== []) : ?>
+        <li class="d-flex gap-2 mb-2">
+            <span class="icon-location text-primary mt-1" aria-hidden="true"></span>
+            <span><?php echo implode('<br>', $addressParts); ?></span>
+        </li>
+    <?php endif; ?>
 
-					<span class="cwmconnect-street" itemprop="streetAddress">
-                        <?php echo nl2br($this->member->attribs->get('mailingaddress')) . ', <br />'; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->suburb && $this->params->get('show_suburb')) : ?>
-					<span class="cwmconnect-suburb" itemprop="addressLocality">
-                        <?php echo $this->member->attribs->get('mailingsuburb') . ', '; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->state && $this->params->get('show_state')) : ?>
-					<span class="cwmconnect-state" itemprop="addressRegion">
-                        <?php echo $this->member->attribs->get('mailingstate'); ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->postcode && $this->params->get('show_postcode')) : ?>
-					<span class="cwmconnect-postcode" itemprop="postalCode">
-                        <?php echo $this->member->attribs->get('mailingpostcode'); ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->country && $this->params->get('show_country')) : ?>
-					<span class="cwmconnect-country" itemprop="addressCountry">
-                        <?php echo $this->member->attribs->get('mailingcountry'); ?>
-                    </span>
-				<?php endif; ?>
-			</dd>
-		<?php endif; ?>
-		<?php if (($this->params->get('address_check') > 0) && ($this->member->address || $this->member->suburb || $this->member->state || $this->member->country || $this->member->postcode)) : ?>
-			<?php if ($this->params->get('address_check') > 0) : ?>
-				<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-                    <?php echo $this->params->get('marker_address'); ?>
-                </span>
-				</dt>
-			<?php endif; ?>
-			<dd>
-				<?php if ($this->member->address && $this->params->get('show_street_address')) : ?>
+    <?php if ($member->email_to && $params->get('show_email')) : ?>
+        <li class="d-flex gap-2 mb-2">
+            <span class="icon-envelope text-primary mt-1" aria-hidden="true"></span>
+            <span class="cwmconnect-emailto"><?php echo $member->email_to; // pre-cloaked HTML?></span>
+        </li>
+    <?php endif; ?>
 
-					<span class="cwmconnect-street" itemprop="streetAddress">
-                        <?php echo nl2br($this->member->address) . ', <br />'; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->suburb && $this->params->get('show_suburb')) : ?>
-					<span class="cwmconnect-suburb" itemprop="addressLocality">
-                        <?php echo $this->member->suburb . ', '; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->state && $this->params->get('show_state')) : ?>
-					<span class="cwmconnect-state" itemprop="addressRegion">
-                        <?php echo $this->member->state; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->postcode && $this->params->get('show_postcode')) : ?>
-					<span class="cwmconnect-postcode" itemprop="postalCode">
-                        <?php echo $this->member->postcode; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->country && $this->params->get('show_country')) : ?>
-					<span class="cwmconnect-country" itemprop="addressCountry">
-                        <?php echo $this->member->country; ?>
-                    </span>
-				<?php endif; ?>
-			</dd>
-		<?php endif; ?>
-	<?php elseif ($this->params->get('show_address_full') != '1') : ?>
-		<?php if ($this->member->attribs->get('mailingaddress') || $this->member->attribs->get('mailingsuburb') || $this->member->attribs->get('mailingstate')): ?>
-			<?php if ($this->params->get('address_check') > 0) : ?>
-				<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-                    <?php echo $this->params->get('marker_address'); ?>
-                </span>
-				</dt>
-			<?php endif; ?>
-			<dd>
-				<?php if ($this->member->address && $this->params->get('show_street_address')) : ?>
+    <?php if ($member->telephone && $params->get('show_telephone')) : ?>
+        <li class="d-flex gap-2 mb-2">
+            <span class="icon-phone text-primary mt-1" aria-hidden="true"></span>
+            <span itemprop="telephone"><?php echo nl2br($this->escape($member->telephone)); ?></span>
+        </li>
+    <?php endif; ?>
 
-					<span class="cwmconnect-street" itemprop="streetAddress">
-                        <?php echo nl2br($this->member->attribs->get('mailingaddress')) . ', <br />'; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->suburb && $this->params->get('show_suburb')) : ?>
-					<span class="cwmconnect-suburb" itemprop="addressLocality">
-                        <?php echo $this->member->attribs->get('mailingsuburb') . ', '; ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->state && $this->params->get('show_state')) : ?>
-					<span class="cwmconnect-state" itemprop="addressRegion">
-                        <?php echo $this->member->attribs->get('mailingstate'); ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->postcode && $this->params->get('show_postcode')) : ?>
-					<span class="cwmconnect-postcode" itemprop="postalCode">
-                        <?php echo $this->member->attribs->get('mailingpostcode'); ?>
-                    </span>
-				<?php endif; ?>
-				<?php if ($this->member->country && $this->params->get('show_country')) : ?>
-					<span class="cwmconnect-country" itemprop="addressCountry">
-                        <?php echo $this->member->attribs->get('mailingcountry'); ?>
-                    </span>
-				<?php endif; ?>
-			</dd>
-		<?php else: ?>
-			<?php if (($this->params->get('address_check') > 0) && ($this->member->address || $this->member->suburb || $this->member->state || $this->member->country || $this->member->postcode)) : ?>
-				<?php if ($this->params->get('address_check') > 0) : ?>
-					<dt>
-                <span class="<?php echo $this->params->get('marker_class'); ?>">
-                    <?php echo $this->params->get('marker_address'); ?>
-                </span>
-					</dt>
-				<?php endif; ?>
-				<dd>
-					<?php if ($this->member->address && $this->params->get('show_street_address')) : ?>
-						<span class="cwmconnect-street" itemprop="streetAddress">
-                        <?php echo nl2br($this->member->address) . ', <br />'; ?>
-                    </span>
-					<?php endif; ?>
-					<?php if ($this->member->suburb && $this->params->get('show_suburb')) : ?>
-						<span class="cwmconnect-suburb" itemprop="addressLocality">
-                        <?php echo $this->member->suburb . ', '; ?>
-                    </span>
-					<?php endif; ?>
-					<?php if ($this->member->state && $this->params->get('show_state')) : ?>
-						<span class="cwmconnect-state" itemprop="addressRegion">
-                        <?php echo $this->member->state; ?>
-                    </span>
-					<?php endif; ?>
-					<?php if ($this->member->postcode && $this->params->get('show_postcode')) : ?>
-						<span class="cwmconnect-postcode" itemprop="postalCode">
-                        <?php echo $this->member->postcode; ?>
-                    </span>
-					<?php endif; ?>
-					<?php if ($this->member->country && $this->params->get('show_country')) : ?>
-						<span class="cwmconnect-country" itemprop="addressCountry">
-                        <?php echo $this->member->country; ?>
-                    </span>
-					<?php endif; ?>
-				</dd>
-			<?php endif; ?>
-		<?php endif; ?>
-	<?php endif; ?>
+    <?php if ($member->mobile && $params->get('show_mobile')) : ?>
+        <li class="d-flex gap-2 mb-2">
+            <span class="icon-mobile text-primary mt-1" aria-hidden="true"></span>
+            <span itemprop="telephone"><?php echo nl2br($this->escape($member->mobile)); ?></span>
+        </li>
+    <?php endif; ?>
 
-	<?php if ($this->params->get('show_email') || $this->params->get('show_telephone') || $this->params->get('show_fax') || $this->params->get('show_mobile') || $this->params->get('show_webpage')) : ?>
-	<?php endif; ?>
-	<?php if ($this->member->email_to && $this->params->get('show_email')) : ?>
-		<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-                <?php echo $this->params->get('marker_email'); ?>
-            </span>
-		</dt>
-		<dd>
-            <span class="cwmconnect-emailto">
-                <?php echo $this->member->email_to; ?>
-            </span>
-		</dd>
-	<?php endif; ?>
+    <?php if ($member->fax && $params->get('show_fax')) : ?>
+        <li class="d-flex gap-2 mb-2">
+            <span class="icon-print text-primary mt-1" aria-hidden="true"></span>
+            <span itemprop="faxNumber"><?php echo nl2br($this->escape($member->fax)); ?></span>
+        </li>
+    <?php endif; ?>
 
-	<?php if ($this->member->telephone && $this->params->get('show_telephone')) : ?>
-		<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-                <?php echo $this->params->get('marker_telephone'); ?>
-            </span>
-		</dt>
-		<dd>
-            <span class="cwmconnect-telephone" itemprop="telephone">
-                <?php echo nl2br($this->member->telephone); ?>
-            </span>
-		</dd>
-	<?php endif; ?>
-	<?php if ($this->member->fax && $this->params->get('show_fax')) : ?>
-		<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-                <?php echo $this->params->get('marker_fax'); ?>
-            </span>
-		</dt>
-		<dd>
-            <span class="cwmconnect-fax" itemprop="faxNumber">
-                <?php echo nl2br($this->member->fax); ?>
-            </span>
-		</dd>
-	<?php endif; ?>
-	<?php if ($this->member->mobile && $this->params->get('show_mobile')) : ?>
-		<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-                <?php echo $this->params->get('marker_mobile'); ?>
-            </span>
-		</dt>
-		<dd>
-            <span class="cwmconnect-mobile" itemprop="telephone">
-                <?php echo nl2br($this->member->mobile); ?>
-            </span>
-		</dd>
-	<?php endif; ?>
-	<?php if ($this->member->webpage && $this->params->get('show_webpage')) : ?>
-		<dt>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
-            </span>
-		</dt>
-		<dd>
-            <span class="cwmconnect-webpage">
-                <?php if (substr_count($this->member->webpage, 'http://', 0)) {
-                    $a = '';
-                } else {
-                    $a = 'http://';
-                } ?>
-	            <a href="<?php echo $a . $this->member->webpage; ?>" target="_blank">
-		            <?php echo JStringPunycode::urlToUTF8($this->member->webpage); ?></a>
-            </span>
-		</dd>
-	<?php endif; ?>
-</dl>
+    <?php if ($webHref !== '') : ?>
+        <li class="d-flex gap-2">
+            <span class="icon-out-2 text-primary mt-1" aria-hidden="true"></span>
+            <a href="<?php echo $this->escape($webHref); ?>" target="_blank" rel="noopener">
+                <?php echo $this->escape(PunycodeHelper::urlToUTF8($member->webpage)); ?>
+            </a>
+        </li>
+    <?php endif; ?>
+</ul>

--- a/site/tmpl/member/default_form.php
+++ b/site/tmpl/member/default_form.php
@@ -4,90 +4,72 @@
  * @package    Cwmconnect.Site
  * @copyright  (C) 2026 CWM Team All rights reserved
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
  */
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
-use CWM\Component\Cwmconnect\Site\Helper\RenderHelper;
-use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Uri\Uri;
+
+/** @var \CWM\Component\Cwmconnect\Site\View\Member\HtmlView $this */
 
 // J5/J6: behavior.formvalidation + behavior.tooltip were removed. Load the
-// form-validate + keepalive web assets and Bootstrap tooltips instead.
+// keepalive + form-validate web assets and Bootstrap tooltips instead.
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('keepalive')->useScript('form.validate');
 HTMLHelper::_('bootstrap.tooltip', '.hasTooltip');
-if (isset($this->error)) : ?>
-<div class="cwmconnect-error">
-	<?php echo $this->error; ?>
-</div>
+
+$fields = ['cwmconnect_name', 'cwmconnect_email', 'cwmconnect_subject', 'cwmconnect_message'];
+
+if ($this->params->get('show_email_copy')) {
+    $fields[] = 'cwmconnect_email_copy';
+}
+?>
+<?php if (isset($this->error)) : ?>
+    <div class="alert alert-danger"><?php echo $this->error; ?></div>
 <?php endif; ?>
 
-<div class="cwmconnect-form">
-    <form id="cwmconnect-form" action="<?php echo Route::_('index.php'); ?>" method="post" class="form-validate">
-        <fieldset>
-            <legend><?php echo Text::_('COM_CWMCONNECT_FORM_LABEL'); ?></legend>
-            <div class="control-group">
-                <div class="control-label"><?php echo $this->form->getLabel('cwmconnect_name'); ?></div>
-                <div class="controls"><?php echo $this->form->getInput('cwmconnect_name'); ?></div>
-            </div>
-            <div class="control-group">
-                <div class="control-label"><?php echo $this->form->getLabel('cwmconnect_email'); ?></div>
-                <div class="controls"><?php echo $this->form->getInput('cwmconnect_email'); ?></div>
-            </div>
-            <div class="control-group">
-                <div class="control-label"><?php echo $this->form->getLabel('cwmconnect_subject'); ?></div>
-                <div class="controls"><?php echo $this->form->getInput('cwmconnect_subject'); ?></div>
-            </div>
-            <div class="control-group">
-                <div class="control-label"><?php echo $this->form->getLabel('cwmconnect_message'); ?></div>
-                <div class="controls"><?php echo $this->form->getInput('cwmconnect_message'); ?></div>
-            </div>
-			<?php if ($this->params->get('show_email_copy')) { ?>
-            <div class="control-group">
-                <div class="control-label"><?php echo $this->form->getLabel('cwmconnect_email_copy'); ?></div>
-                <div class="controls"><?php echo $this->form->getInput('cwmconnect_email_copy'); ?></div>
-            </div>
-			<?php } ?>
-			<?php // Dynamically load any additional fields from plugins.?>
-			<?php foreach ($this->form->getFieldsets() as $fieldset): ?>
-			<?php if ($fieldset->name != 'member'): ?>
-				<?php $fields = $this->form->getFieldset($fieldset->name); ?>
-				<?php foreach ($fields as $field): ?>
-                    <div class="control-group">
-						<?php if ($field->hidden): ?>
-                        <div class="controls">
-							<?php echo $field->input; ?>
-                        </div>
-						<?php else: ?>
-                        <div class="control-label">
-							<?php echo $field->label; ?>
-							<?php if (!$field->required && $field->type != "Spacer"): ?>
-                            <span class="optional"><?php echo Text::_('COM_CWMCONNECT_OPTIONAL'); ?></span>
-							<?php endif; ?>
-                        </div>
-                        <div class="controls"><?php echo $field->input; ?></div>
-						<?php endif; ?>
-                    </div>
-					<?php endforeach; ?>
-				<?php endif ?>
-			<?php endforeach; ?>
-            <div class="form-actions">
-                <button class="btn btn-primary validate"
-                        type="submit"><?php echo Text::_('COM_CWMCONNECT_MEMBER_SEND'); ?></button>
-                <input type="hidden" name="option" value="com_cwmconnect"/>
-                <input type="hidden" name="task" value="member.submit"/>
-                <input type="hidden" name="return" value="<?php echo $this->return_page; ?>"/>
-                <input type="hidden" name="id" value="<?php echo $this->member->slug; ?>"/>
-				<?php echo HTMLHelper::_('form.token'); ?>
-            </div>
-        </fieldset>
-    </form>
-</div>
+<form id="cwmconnect-form" action="<?php echo Route::_('index.php'); ?>" method="post" class="form-validate cwmconnect-form">
+    <?php foreach ($fields as $field) : ?>
+        <div class="mb-3">
+            <?php echo $this->form->getLabel($field); ?>
+            <?php echo $this->form->getInput($field); ?>
+        </div>
+    <?php endforeach; ?>
+
+    <?php // Dynamically load any additional fields from plugins.?>
+    <?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
+        <?php if ($fieldset->name !== 'member') : ?>
+            <?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
+                <div class="mb-3">
+                    <?php if ($field->hidden) : ?>
+                        <?php echo $field->input; ?>
+                    <?php else : ?>
+                        <?php echo $field->label; ?>
+                        <?php if (!$field->required && $field->type !== 'Spacer') : ?>
+                            <span class="text-body-tertiary small">(<?php echo Text::_('COM_CWMCONNECT_OPTIONAL'); ?>)</span>
+                        <?php endif; ?>
+                        <?php echo $field->input; ?>
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    <?php endforeach; ?>
+
+    <div class="d-flex">
+        <button class="btn btn-primary validate" type="submit">
+            <span class="icon-envelope" aria-hidden="true"></span> <?php echo Text::_('COM_CWMCONNECT_MEMBER_SEND'); ?>
+        </button>
+    </div>
+
+    <input type="hidden" name="option" value="com_cwmconnect">
+    <input type="hidden" name="task" value="member.submit">
+    <input type="hidden" name="return" value="<?php echo $this->return_page; ?>">
+    <input type="hidden" name="id" value="<?php echo $this->member->slug; ?>">
+    <?php echo HTMLHelper::_('form.token'); ?>
+</form>

--- a/site/tmpl/member/default_household.php
+++ b/site/tmpl/member/default_household.php
@@ -4,6 +4,7 @@
  * @package    Cwmconnect.Site
  * @copyright  (C) 2026 CWM Team All rights reserved
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
  */
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -11,6 +12,7 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Cwmconnect\Site\Helper\HouseholdVisibility;
+use CWM\Component\Cwmconnect\Site\Helper\Layout;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
@@ -20,35 +22,44 @@ if ($this->householdMembers === [] && $this->hiddenHouseholdCount === 0) {
     return;
 }
 
-$showsNames    = HouseholdVisibility::showsChildNames($this->householdScope);
-$visibleByName = $this->householdMembers;
-$hiddenCount   = (int) $this->hiddenHouseholdCount;
+$showsNames  = HouseholdVisibility::showsChildNames($this->householdScope);
+$hiddenCount = (int) $this->hiddenHouseholdCount;
 ?>
-<div class="cwmconnect-household mt-4">
-    <h3 class="h5"><?php echo Text::_('COM_CWMCONNECT_MEMBER_HOUSEHOLD_HEADING'); ?></h3>
+<?php if ($this->householdMembers !== []) : ?>
+    <ul class="list-unstyled mb-0 cwm-household">
+        <?php foreach ($this->householdMembers as $hm) :
+            $url      = Route::_('index.php?option=com_cwmconnect&view=member&id=' . (int) $hm->id);
+            $name     = trim(($hm->name ?: '') ?: ($hm->lname ?: ''));
+            $isHidden = (int) ($hm->display_in_directory ?? 1) === 0;
+            $photo    = Layout::render('photo', [
+                'id'       => (int) $hm->id,
+                'hasPhoto' => !empty($hm->image),
+                'alt'      => $name,
+                'sizes'    => '40px',
+                'width'    => 40,
+                'height'   => 40,
+                'rounded'  => true,
+                'class'    => 'flex-shrink-0',
+            ]);
+            ?>
+            <li class="d-flex align-items-center gap-2 mb-2">
+                <?php if ($isHidden && $showsNames) : ?>
+                    <?php echo $photo; ?>
+                    <span class="text-body-secondary"><?php echo $this->escape($name); ?></span>
+                    <span class="badge bg-body-secondary text-body-secondary"><?php echo Text::_('COM_CWMCONNECT_MEMBER_HOUSEHOLD_HIDDEN_TAG'); ?></span>
+                <?php else : ?>
+                    <a class="d-flex align-items-center gap-2 text-decoration-none text-body" href="<?php echo $url; ?>">
+                        <?php echo $photo; ?>
+                        <span><?php echo $this->escape($name); ?></span>
+                    </a>
+                <?php endif; ?>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+<?php endif; ?>
 
-    <?php if ($visibleByName !== []) : ?>
-        <ul class="list-unstyled">
-            <?php foreach ($visibleByName as $hm) :
-                $url  = Route::_('index.php?option=com_cwmconnect&view=member&id=' . (int) $hm->id);
-                $name = trim(($hm->name ?: '') ?: ($hm->lname ?: ''));
-                $isHidden = (int) ($hm->display_in_directory ?? 1) === 0;
-                ?>
-                <li>
-                    <?php if ($isHidden && $showsNames) : ?>
-                        <span class="text-muted"><?php echo $this->escape($name); ?></span>
-                        <span class="badge bg-light text-dark"><?php echo Text::_('COM_CWMCONNECT_MEMBER_HOUSEHOLD_HIDDEN_TAG'); ?></span>
-                    <?php else : ?>
-                        <a href="<?php echo $url; ?>"><?php echo $this->escape($name); ?></a>
-                    <?php endif; ?>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-    <?php endif; ?>
-
-    <?php if (!$showsNames && $hiddenCount > 0) : ?>
-        <p class="text-muted small">
-            <?php echo Text::plural('COM_CWMCONNECT_MEMBER_HOUSEHOLD_AND_N_CHILDREN', $hiddenCount); ?>
-        </p>
-    <?php endif; ?>
-</div>
+<?php if (!$showsNames && $hiddenCount > 0) : ?>
+    <p class="text-body-secondary small mb-0">
+        <?php echo Text::plural('COM_CWMCONNECT_MEMBER_HOUSEHOLD_AND_N_CHILDREN', $hiddenCount); ?>
+    </p>
+<?php endif; ?>


### PR DESCRIPTION
First slice of the site-wide front-end modernization (plan: `docs/site-modernization-plan.md`).

## Phase 0 — Shared BS5 layout foundation
Reusable partials under `components/com_cwmconnect/layouts/cwmconnect/` (via a thin `Site\Helper\Layout` wrapper) so every view composes the same blocks:
- **photo** — responsive member/household image (thumb/medium `srcset`, WebP/JPEG via the proxy, lazy, optional click-to-full, neutral placeholder)
- **membercard**, **sectioncard**, **pageheader**, **emptystate**

## Phase 1 — Modern member profile
Replaced the Joomla-3 markup (BS2 `span*`/`pull-*`, `img-polaroid`, `dl-horizontal`, tabs/sliders/plain) with a responsive BS5 layout:
- **Hero header**: photo + name (+ Unpublished badge) + position/category/household chips + Email/vCard buttons
- **Section cards**: Contact (icon rows), Household (with member **avatars**), Other info, Links, Articles, and the Email-this-member form
- `default_address` / `default_household` / `default_form` rewritten onto the shared partials

Dropped: `presentation_style` (tabs/sliders/plain) and the niche Joomla-profile section. 164 tests green, php-cs-fixer + eslint clean. Layout path verified on the dev install.

Phases 2 (home/landing) and 3 (polish the already-BS5 views) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)