### PR TITLE
Site UI Phase 3: unify directory views onto the shared partials

### DIFF
--- a/site/tmpl/category/default_items.php
+++ b/site/tmpl/category/default_items.php
@@ -10,6 +10,7 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Cwmconnect\Site\Helper\Layout;
 use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -48,9 +49,15 @@ $teamleaders      = (string) $this->params->get('teamleaders', '1');
 
             <p>
                 <?php if ($this->params->get('show_image_headings')) : ?>
-                    <img src="<?php echo $this->escape(Route::_(RouteHelper::getPhotoRoute((int) $item->id, 'thumb'))); ?>"
-                         alt="<?php echo $this->escape(Text::_('COM_CWMCONNECT_IMAGE_DETAILS')); ?>"
-                         height="100" width="100" loading="lazy" decoding="async" />
+                    <?php echo Layout::render('photo', [
+                        'id'       => (int) $item->id,
+                        'hasPhoto' => (string) ($item->image ?? '') !== '',
+                        'alt'      => $item->name,
+                        'sizes'    => '100px',
+                        'width'    => 100,
+                        'height'   => 100,
+                        'rounded'  => true,
+                    ]); ?>
                 <?php endif; ?>
                 <br/>
                 <strong class="list-title">
@@ -67,16 +74,12 @@ $teamleaders      = (string) $this->params->get('teamleaders', '1');
                 <br/>
 
                 <?php if ($this->params->get('show_position_headings') && $item->con_position && $this->params->get('show_position')) : ?>
-                    <dl class="contact-position">
-                        <dt>
-                            <?php if ($item->con_position != '-1') : ?>
-                                <?php echo Text::_('COM_CWMCONNECT_POSITIONS'); ?>
-                            <?php endif; ?>
-                        </dt>
-                        <dd>
-                            <?php echo $this->renderHelper->getPosition($item->con_position); ?>
-                        </dd>
-                    </dl>
+                    <div class="small text-body-secondary">
+                        <?php if ($item->con_position != '-1') : ?>
+                            <?php echo Text::_('COM_CWMCONNECT_POSITIONS'); ?>:
+                        <?php endif; ?>
+                        <?php echo $this->renderHelper->getPosition($item->con_position); ?>
+                    </div>
                 <?php endif; ?>
 
                 <?php if ($this->params->get('show_email_headings')) : ?>

--- a/site/tmpl/category/default_teamleaders.php
+++ b/site/tmpl/category/default_teamleaders.php
@@ -10,6 +10,7 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Cwmconnect\Site\Helper\Layout;
 use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -47,9 +48,15 @@ $teamleaders      = (string) $this->params->get('teamleaders', '1');
             </span>
 
             <p>
-                <img src="<?php echo $this->escape(Route::_(RouteHelper::getPhotoRoute((int) $item->id, 'thumb'))); ?>"
-                     alt="<?php echo $this->escape(Text::_('COM_CWMCONNECT_IMAGE_DETAILS')); ?>"
-                     height="100" width="100" loading="lazy" decoding="async" />
+                <?php echo Layout::render('photo', [
+                    'id'       => (int) $item->id,
+                    'hasPhoto' => (string) ($item->image ?? '') !== '',
+                    'alt'      => $item->name,
+                    'sizes'    => '100px',
+                    'width'    => 100,
+                    'height'   => 100,
+                    'rounded'  => true,
+                ]); ?>
                 <br/>
                 <strong class="list-title">
                     <a href="<?php echo Route::_(RouteHelper::getMemberRoute($item->slug, $item->catid)); ?>">

--- a/site/tmpl/featured/default_items.php
+++ b/site/tmpl/featured/default_items.php
@@ -10,6 +10,7 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Cwmconnect\Site\Helper\Layout;
 use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -23,7 +24,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <?php if (empty($this->items)) : ?>
-    <p><?php echo Text::_('COM_CWMCONNECT_NO_MEMBERS'); ?></p>
+    <?php echo Layout::render('emptystate', [
+        'icon'    => 'icon-users',
+        'message' => Text::_('COM_CWMCONNECT_NO_MEMBERS'),
+    ]); ?>
 <?php else : ?>
     <form action="<?php echo htmlspecialchars(Uri::getInstance()->toString()); ?>" method="post"
           name="adminForm" id="adminForm">
@@ -39,7 +43,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
             <input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>"/>
         </fieldset>
 
-        <table class="category">
+        <table class="table table-striped table-hover">
             <?php if ($this->params->get('show_headings')) : ?>
                 <thead>
                 <tr>

--- a/site/tmpl/members/default.php
+++ b/site/tmpl/members/default.php
@@ -11,9 +11,8 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
-use CWM\Component\Cwmconnect\Site\Helper\RouteHelper;
+use CWM\Component\Cwmconnect\Site\Helper\Layout;
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
@@ -71,38 +70,21 @@ if ($menuItems) {
     </div>
 
     <?php if ($this->items === []) : ?>
-        <div class="alert alert-info">
-            <?php echo Text::_('COM_CWMCONNECT_MEMBERS_EMPTY'); ?>
-        </div>
+        <?php echo Layout::render('emptystate', [
+            'icon'    => 'icon-users',
+            'message' => Text::_('COM_CWMCONNECT_MEMBERS_EMPTY'),
+        ]); ?>
     <?php elseif ($layoutMode === 'grid') : ?>
         <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 cwmconnect-photo-grid">
-            <?php foreach ($this->items as $item) :
-                $profileUrl = Route::_('index.php?option=com_cwmconnect&view=member&id=' . (int) $item->id . '&Itemid=' . $memberItemId);
-                $imgPath    = (string) ($item->image ?? '');
-                $imgUrl     = $imgPath !== '' ? Route::_(RouteHelper::getPhotoRoute((int) $item->id, 'thumb')) : '';
-                $imgSrcset  = $imgPath !== '' ? RouteHelper::getPhotoSrcset((int) $item->id) : '';
-                $name       = trim(($item->name ?: '') ?: ($item->lname ?: ''));
-                ?>
+            <?php foreach ($this->items as $item) : ?>
                 <div class="col">
-                    <a class="card h-100 text-decoration-none text-body" href="<?php echo $profileUrl; ?>">
-                        <?php if ($imgUrl !== '') : ?>
-                            <img class="card-img-top" src="<?php echo $this->escape($imgUrl); ?>"
-                                 srcset="<?php echo $this->escape($imgSrcset); ?>"
-                                 sizes="(max-width: 600px) 50vw, 300px"
-                                 width="300" height="400" decoding="async"
-                                 alt="<?php echo $this->escape($name); ?>" loading="lazy">
-                        <?php else : ?>
-                            <div class="card-img-top d-flex align-items-center justify-content-center bg-light text-muted" style="aspect-ratio: 1/1;">
-                                <span class="icon-user" aria-hidden="true" style="font-size: 3rem;"></span>
-                            </div>
-                        <?php endif; ?>
-                        <div class="card-body">
-                            <div class="fw-semibold"><?php echo $this->escape($name); ?></div>
-                            <?php if ($item->category_title) : ?>
-                                <div class="small text-muted"><?php echo $this->escape((string) $item->category_title); ?></div>
-                            <?php endif; ?>
-                        </div>
-                    </a>
+                    <?php echo Layout::render('membercard', [
+                        'id'         => (int) $item->id,
+                        'name'       => trim(($item->name ?: '') ?: ($item->lname ?: '')),
+                        'hasPhoto'   => (string) ($item->image ?? '') !== '',
+                        'profileUrl' => Route::_('index.php?option=com_cwmconnect&view=member&id=' . (int) $item->id . '&Itemid=' . $memberItemId),
+                        'household'  => (string) ($item->household_name ?? ''),
+                    ]); ?>
                 </div>
             <?php endforeach; ?>
         </div>


### PR DESCRIPTION
Phase 3 of the site modernization (plan: `docs/site-modernization-plan.md`) — consistency polish so every view composes the same Phase 0 partials.

- **members** browse grid → `membercard`; empty case → `emptystate`
- **category** member lists (`default_items`/`default_teamleaders`) → rounded `photo` partial; BS2 `dl` → clean inline position
- **featured** → `emptystate` + modern BS5 table classes

Households / myprofile / directory were already clean; the category *core* views stay pending the category-system review.

164 tests green, fresh `composer lint` (cache cleared) + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)