### PR TITLE
fix(sync): release session lock so PC sync progress poll works

### DIFF
--- a/admin/src/Controller/CpanelController.php
+++ b/admin/src/Controller/CpanelController.php
@@ -139,6 +139,13 @@ class CpanelController extends BaseController
     {
         $this->assertAdminAjax();
 
+        // Release the session write-lock now that auth + CSRF have been checked.
+        // The sync runs for 20-30s; without this the PHP session file stays
+        // exclusively locked for the whole request and every concurrent
+        // `pcSyncProgress` poll blocks until the sync ends — so the progress
+        // spinner would never update mid-run. Nothing below writes to session.
+        $this->app->getSession()->close();
+
         $progressFile = $this->progressFilePath();
 
         try {


### PR DESCRIPTION
## Problem

The Cpanel PC-sync progress UI (spinner that should tick through page/member counts) was **fully built on both ends but never updated mid-sync** — it just sat on the initial "Syncing…" text and looked frozen for the whole 20–30s run. This is the "looks frozen during the 23-second sync" symptom from live testing.

Root cause is a classic PHP **session-lock** bug, not a missing feature:

- `SyncEngine::run($statuses, $onProgress)` already emits `preparing`/`fetching`/`sweeping` phases.
- `CpanelController::pcSync()` already writes per-page snapshots to a per-user cache file; `pcSyncProgress()` already serves them; `admin-pc-sync.es6.js` already polls every 1s.
- **But** Joomla acquires an exclusive PHP session-file lock at request boot. `pcSync` held that lock for the entire sync, so every concurrent `pcSyncProgress` poll from the same browser blocked until the sync finished. All the progress responses then arrived at once at the end → spinner never updated.

## Fix

Close the session for writing in `pcSync()` immediately after the auth + CSRF checks (nothing downstream writes to the session), releasing the lock so the poll requests interleave and report real page/member counts. Mirrors core's Smart Search indexer, which closes the session before its long indexing loop for the same reason.

One line + explanatory comment in `admin/src/Controller/CpanelController.php`.

## Verification

- `php -l` clean
- `composer lint` clean (php-cs-fixer cache cleared first)
- `composer test` — **164 tests, 421 assertions, green**
- ⚠️ Not yet live-verified against a real 20–30s sync (can't run a live PC sync from dev tooling). Worth confirming the spinner ticks through page counts next live-testing session. If polls still feel sticky, also close the session early in `pcSyncProgress()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)