### PR TITLE
fix(pdf): store structured PC name parts; stop surname doubling

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -76,6 +76,10 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_details` (
   `version`          INT(10) UNSIGNED    NOT NULL DEFAULT '1',
   `hits`             INT(10) UNSIGNED    NOT NULL DEFAULT '0',
   `surname`          VARCHAR(255)        NOT NULL DEFAULT '',
+  `fname`            VARCHAR(255)        NOT NULL DEFAULT '',
+  `mname`            VARCHAR(255)        NOT NULL DEFAULT '',
+  `nickname`         VARCHAR(255)        NOT NULL DEFAULT '',
+  `suffix`           VARCHAR(64)         NOT NULL DEFAULT '',
   `mstatus`          TINYINT(3)          NOT NULL DEFAULT '0'
   COMMENT 'Used to track Members Status',
   PRIMARY KEY (`id`),

--- a/admin/sql/updates/mysql/2.0.0-20260602-e.sql
+++ b/admin/sql/updates/mysql/2.0.0-20260602-e.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `#__cwmconnect_details` ADD `fname` VARCHAR(255) NOT NULL DEFAULT '';
+
+ALTER TABLE `#__cwmconnect_details` ADD `mname` VARCHAR(255) NOT NULL DEFAULT '';
+
+ALTER TABLE `#__cwmconnect_details` ADD `nickname` VARCHAR(255) NOT NULL DEFAULT '';
+
+ALTER TABLE `#__cwmconnect_details` ADD `suffix` VARCHAR(64) NOT NULL DEFAULT '';

--- a/admin/src/Service/Pc/PersonMapper.php
+++ b/admin/src/Service/Pc/PersonMapper.php
@@ -99,6 +99,12 @@ final class PersonMapper
             'name'                 => $fullName !== '' ? $fullName : $this->stringAttr($attrs, 'name'),
             'lname'                => $lastName,
             'surname'              => $lastName,
+            // Structured PC name parts stored like-for-like so display names can
+            // be composed without re-parsing the computed `name`.
+            'fname'                => $firstName,
+            'mname'                => $middleName,
+            'nickname'             => $nickname,
+            'suffix'               => $suffix,
             'alias'                => $this->buildAlias($firstName, $lastName, $pcPersonId),
             'email_to'             => $primaryEmail,
             'telephone'            => $primaryPhone,

--- a/site/src/Model/MembersModel.php
+++ b/site/src/Model/MembersModel.php
@@ -90,6 +90,8 @@ class MembersModel extends ListModel
             $db->quoteName('a.name'),
             $db->quoteName('a.lname'),
             $db->quoteName('a.surname'),
+            $db->quoteName('a.fname'),
+            $db->quoteName('a.nickname'),
             $db->quoteName('a.alias'),
             $db->quoteName('a.email_to'),
             $db->quoteName('a.telephone'),

--- a/site/src/Service/DirectoryPdfPresenter.php
+++ b/site/src/Service/DirectoryPdfPresenter.php
@@ -239,8 +239,8 @@ final class DirectoryPdfPresenter
     public function memberName(object $item): string
     {
         $surname = trim((string) ($item->surname ?? '')) ?: trim((string) ($item->lname ?? ''));
-        $given   = trim((string) ($item->name ?? ''));
         $spouse  = trim((string) ($item->spouse ?? ''));
+        $given   = $this->memberGiven($item);
 
         $label = $given;
 
@@ -258,6 +258,46 @@ final class DirectoryPdfPresenter
     }
 
     /**
+     * The given-name portion for the inverted "Surname, Given" directory label.
+     *
+     * Prefers the structured `fname` (+ `nickname`) the PC sync now stores
+     * like-for-like. Falls back — for manual rows or any not yet re-synced — to
+     * stripping the surname out of the full display `name` so the inverted label
+     * doesn't repeat it ("Ababio, Gifty B." not "Ababio, Gifty B. Ababio").
+     *
+     * @param   object  $item
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function memberGiven(object $item): string
+    {
+        $first = trim((string) ($item->fname ?? ''));
+
+        if ($first !== '') {
+            $nick = trim((string) ($item->nickname ?? ''));
+
+            return ($nick !== '' && strcasecmp($nick, $first) !== 0)
+                ? $first . ' (' . $nick . ')'
+                : $first;
+        }
+
+        $given   = trim((string) ($item->name ?? ''));
+        $surname = trim((string) ($item->surname ?? '')) ?: trim((string) ($item->lname ?? ''));
+
+        if ($surname === '' || $given === '') {
+            return $given;
+        }
+
+        $stripped = preg_replace('/\b' . preg_quote($surname, '/') . '\b/u', '', $given);
+        $stripped = trim((string) preg_replace('/\s+,/', ',', (string) $stripped));
+        $stripped = trim(preg_replace('/\s{2,}/', ' ', $stripped) ?? '', " ,");
+
+        return $stripped !== '' ? $stripped : $given;
+    }
+
+    /**
      * Up-to-two-letter initials for the no-photo placeholder.
      *
      * @param   object  $item
@@ -268,7 +308,7 @@ final class DirectoryPdfPresenter
      */
     public function memberInitials(object $item): string
     {
-        $given   = trim((string) ($item->name ?? ''));
+        $given   = trim((string) ($item->fname ?? '')) ?: trim((string) ($item->name ?? ''));
         $surname = trim((string) ($item->surname ?? '')) ?: trim((string) ($item->lname ?? ''));
 
         $initials = mb_substr($given, 0, 1) . mb_substr($surname, 0, 1);

--- a/tests/unit/Site/Service/DirectoryPdfPresenterTest.php
+++ b/tests/unit/Site/Service/DirectoryPdfPresenterTest.php
@@ -48,6 +48,7 @@ final class DirectoryPdfPresenterTest extends TestCase
     {
         return (object) array_merge([
             'name'        => '', 'surname' => '', 'lname' => '', 'spouse' => '',
+            'fname'       => '', 'nickname' => '',
             'con_position' => '', 'address' => '', 'suburb' => '', 'state' => '',
             'postcode'    => '', 'anniversary' => '', 'telephone' => '', 'mobile' => '',
             'email_to'    => '', 'image' => '', 'display_in_directory' => 1,
@@ -65,6 +66,28 @@ final class DirectoryPdfPresenterTest extends TestCase
 
         self::assertSame('Brennan', $this->presenter->memberName(self::member(['surname' => 'Brennan'])));
         self::assertSame('', $this->presenter->memberName(self::member([])));
+    }
+
+    #[Test]
+    public function memberNameUsesStructuredFirstNameAndNickname(): void
+    {
+        // Primary path: the PC sync stores fname / nickname like-for-like, so the
+        // given name needs no parsing of the computed full name.
+        self::assertSame('Ababio, Gifty', $this->presenter->memberName(self::member(['surname' => 'Ababio', 'fname' => 'Gifty'])));
+        self::assertSame('Adalla, Antony (Tony)', $this->presenter->memberName(self::member(['surname' => 'Adalla', 'fname' => 'Antony', 'nickname' => 'Tony'])));
+        // A nickname echoing the first name is dropped.
+        self::assertSame('Allen, James', $this->presenter->memberName(self::member(['surname' => 'Allen', 'fname' => 'James', 'nickname' => 'James'])));
+    }
+
+    #[Test]
+    public function memberNameFallsBackToStrippingSurnameWhenNoFirstName(): void
+    {
+        // Fallback path (manual rows / not yet re-synced): no fname, so strip the
+        // surname out of the full display name rather than repeat it.
+        self::assertSame('Ababio, Gifty B.', $this->presenter->memberName(self::member(['surname' => 'Ababio', 'lname' => 'Ababio', 'name' => 'Gifty B. Ababio'])));
+        self::assertSame('Adalla, Antony John (Tony)', $this->presenter->memberName(self::member(['surname' => 'Adalla', 'name' => 'Antony John Adalla (Tony)'])));
+        self::assertSame('Addison-Amponsah, Kwabena A', $this->presenter->memberName(self::member(['surname' => 'Addison-Amponsah', 'name' => 'Kwabena A Addison-Amponsah'])));
+        self::assertSame('Cox, Sherman, III', $this->presenter->memberName(self::member(['surname' => 'Cox', 'name' => 'Sherman Cox, III'])));
     }
 
     #[Test]


### PR DESCRIPTION
## The bug (found live-testing the printed directory)

Picking up the printed directory PDF, I rendered the **real test-bed data** through the actual presenter/template/mpdf and every synced member came out as **"Ababio, Gifty B. Ababio"** — surname twice.

Root cause is a data-model gap, not a formatting one: `PersonMapper` reads PC's `first_name` / `middle_name` / `nickname` and **discards them**, persisting only the computed full `name` plus the last name (`surname`/`lname`). The PDF inverts to "Surname, Given" using `name` as the given part — so the surname already inside the full name repeats. The unit test missed it because it used `name => 'Marie'` (bare first name), which isn't how the sync populates `name`.

## The fix — store PC name parts like-for-like

- **Schema**: new `fname`, `mname`, `nickname`, `suffix` columns (install SQL + migration `2.0.0-20260602-e.sql`; additive — the dev test bed is the only install).
- **`PersonMapper`**: persists first/middle/nickname/suffix alongside the computed name. `ReportsModel` already selects `a.*`; the site `MembersModel` now selects `fname`/`nickname`.
- **`DirectoryPdfPresenter::memberName()`**: composes the given name from `fname` (+ nickname) → e.g. **"Adalla, Antony (Tony)"**. For manual rows or anything not yet re-synced it falls back to stripping the surname out of the full name → **"Ababio, Gifty B."** — correct before *and* after a re-sync.

## Verification

Rendered the real 531-member test bed through mpdf (standalone harness, not committed):
- **roster** and **photo_detail** both show correct, non-doubled names
- real photos render; PC placeholder avatars (200×200, 2–3 KB) correctly fall back to initials cards
- new tests cover both the `fname`-primary and strip-fallback paths
- **166 tests green**, php-cs-fixer clean

> Note: the test bed's `fname` is empty until a **re-sync** repopulates it (the fallback covers the interim). Upgrade SQL files will be consolidated before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)