### PR TITLE
fix(pdf): Church Leaders section = PC Leader switch only

### DIFF
--- a/site/src/View/Members/PdfView.php
+++ b/site/src/View/Members/PdfView.php
@@ -130,13 +130,13 @@ class PdfView extends BaseHtmlView
         }
 
         if ((bool) $params->get('pdf_staff', 1)) {
-            // The PC "leader" switch (is_leader) is the church's leadership
-            // designation; the legacy con_position is kept for manual rows.
+            // The Church Leaders section is exactly the PC "leader" switch
+            // (is_leader = yes) — nobody else, regardless of con_position.
             $presenter->staff = array_values(
                 array_filter(
                     $items,
                     static fn(object $item): bool => !isset($placed[(int) $item->id])
-                        && ((int) ($item->is_leader ?? 0) === 1 || trim((string) ($item->con_position ?? '')) !== ''),
+                        && (int) ($item->is_leader ?? 0) === 1,
                 ),
             );
         }


### PR DESCRIPTION
## Summary
Limit the printed-directory **Church Leaders** front-matter section to members whose PC **Leader switch is yes** (`is_leader = 1`). Previously it also pulled in anyone with non-empty legacy `con_position` text; that fallback is removed so only true leaders appear.

Board → Officers → Leaders dedup precedence is unchanged.

## Test
- Real dev data: 30 leaders total, 10 render in the section (rest dedup up into Board/Officers); 0 `con_position`-only rows existed, so nobody is dropped today — the rule is just correct going forward.
- `composer lint` clean, 174 tests / 456 assertions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)