### PR TITLE
refactor(router): flatten to v2 scheme (Phase 1 of view retirement)

### DIFF
--- a/site/src/Service/Router.php
+++ b/site/src/Service/Router.php
@@ -30,10 +30,11 @@ use Joomla\Database\ParameterType;
 /**
  * Site router for com_cwmconnect.
  *
- * View hierarchy (parent → child):
- *   categories → category → member
- *
- * Plus three flat views: home, directory, featured.
+ * Flat scheme (Phase 1 of the legacy-view retirement): the v2 directory is
+ * menu-driven (`members` / `myprofile` / `households`), and a single id-keyed
+ * `profile` view carries the per-member SEF segment. The legacy
+ * categories→category→member hierarchy and the home/directory/featured views
+ * were dropped here ahead of deleting those view stacks.
  *
  * @since  2.0.0
  */
@@ -42,40 +43,24 @@ class Router extends RouterView
     /** @var bool When true, drop numeric ids from segments and rely on aliases (sef_ids param). */
     protected $noIDs = false;
 
-    private CategoryFactoryInterface $categoryFactory;
-
     private DatabaseInterface $db;
 
+    /**
+     * The 4-arg signature is fixed by the core RouterFactory, which always
+     * calls `new Router($app, $menu, $categoryFactory, $db)` positionally. The
+     * category factory is no longer used (the category hierarchy was dropped in
+     * Phase 1) but must stay in the signature so `$db` binds correctly.
+     */
     public function __construct(
         SiteApplication $app,
         AbstractMenu $menu,
         CategoryFactoryInterface $categoryFactory,
         DatabaseInterface $db,
     ) {
-        $this->categoryFactory = $categoryFactory;
-        $this->db              = $db;
-        $this->noIDs           = (bool) ComponentHelper::getParams('com_cwmconnect')->get('sef_ids');
+        $this->db    = $db;
+        $this->noIDs = (bool) ComponentHelper::getParams('com_cwmconnect')->get('sef_ids');
 
-        $categories = new RouterViewConfiguration('categories')->setKey('id');
-        $this->registerView($categories);
-
-        $category = new RouterViewConfiguration('category')
-            ->setKey('id')
-            ->setParent($categories, 'catid')
-            ->setNestable();
-        $this->registerView($category);
-
-        $member = new RouterViewConfiguration('member')
-            ->setKey('id')
-            ->setParent($category, 'catid');
-        $this->registerView($member);
-
-        $this->registerView(new RouterViewConfiguration('featured'));
-        $this->registerView(new RouterViewConfiguration('directory'));
-        $this->registerView(new RouterViewConfiguration('home'));
-
-        // Phase 0: the v2 single-member profile. Flat, id-keyed — reached from
-        // the directory, not via the legacy categories→category→member chain.
+        // Single-member public profile, reached from the directory list.
         $this->registerView(new RouterViewConfiguration('profile')->setKey('id'));
 
         parent::__construct($app, $menu);
@@ -86,52 +71,16 @@ class Router extends RouterView
     }
 
     /**
-     * Segments for a category — the full ancestor path so nested categories
-     * round-trip cleanly.
+     * Segment for a profile — always `id:alias`, dropping the id when noIDs is on.
      *
-     * @param   int|string                   $id     Category id.
-     * @param   array<string, mixed>         $query  The (mutable) URL query.
-     *
-     * @return  array<int|string, string>
-     *
-     * @since   2.0.0
-     */
-    public function getCategorySegment(int|string $id, array $query): array
-    {
-        $category = $this->categoryFactory
-            ->createCategory(['extension' => 'com_cwmconnect'])
-            ->get($id);
-
-        if (!$category) {
-            return [];
-        }
-
-        $path    = array_reverse($category->getPath(), true);
-        $path[0] = '1:root';
-
-        if ($this->noIDs) {
-            foreach ($path as &$segment) {
-                [, $segment] = explode(':', $segment, 2);
-            }
-        }
-
-        return $path;
-    }
-
-    /** Alias used by RouterView to resolve the categories-view child segment. */
-    public function getCategoriesSegment(int|string $id, array $query): array
-    {
-        return $this->getCategorySegment($id, $query);
-    }
-
-    /**
-     * Segment for a member — always `id:alias`, dropping the id when noIDs is on.
+     * @param   int|string            $id     Member id (optionally `id:alias`).
+     * @param   array<string, mixed>  $query  The (mutable) URL query.
      *
      * @return  array<int|string, string>
      *
      * @since   2.0.0
      */
-    public function getMemberSegment(int|string $id, array $query): array
+    public function getProfileSegment(int|string $id, array $query): array
     {
         if (!str_contains((string) $id, ':')) {
             $dbquery = $this->db->createQuery()
@@ -154,63 +103,24 @@ class Router extends RouterView
     }
 
     /**
-     * Resolve a category segment back to its id by walking the parent's children.
+     * Resolve a profile segment back to its member id. Looks up the alias when
+     * noIDs is on; otherwise takes the leading integer.
      *
-     * @return  int|false
-     *
-     * @since   2.0.0
-     */
-    public function getCategoryId(string $segment, array $query): int|false
-    {
-        if (!isset($query['id'])) {
-            return false;
-        }
-
-        $category = $this->categoryFactory
-            ->createCategory(['extension' => 'com_cwmconnect'])
-            ->get($query['id']);
-
-        if (!$category) {
-            return false;
-        }
-
-        foreach ($category->getChildren() as $child) {
-            if ($this->noIDs) {
-                if ($child->alias === $segment) {
-                    return (int) $child->id;
-                }
-            } elseif ((int) $child->id === (int) $segment) {
-                return (int) $child->id;
-            }
-        }
-
-        return false;
-    }
-
-    /** Alias used by RouterView to resolve the categories-view child segment. */
-    public function getCategoriesId(string $segment, array $query): int|false
-    {
-        return $this->getCategoryId($segment, $query);
-    }
-
-    /**
-     * Resolve a member segment back to its id. Looks up alias-keyed rows when
-     * noIDs is on; falls back to the leading integer otherwise.
+     * @param   string                $segment  The URL segment.
+     * @param   array<string, mixed>  $query    The (mutable) URL query.
      *
      * @return  int
      *
      * @since   2.0.0
      */
-    public function getMemberId(string $segment, array $query): int
+    public function getProfileId(string $segment, array $query): int
     {
         if ($this->noIDs) {
             $dbquery = $this->db->createQuery()
                 ->select($this->db->quoteName('id'))
                 ->from($this->db->quoteName('#__cwmconnect_details'))
                 ->where($this->db->quoteName('alias') . ' = :alias')
-                ->where($this->db->quoteName('catid') . ' = :catid')
-                ->bind(':alias', $segment)
-                ->bind(':catid', $query['id'], ParameterType::INTEGER);
+                ->bind(':alias', $segment);
 
             return (int) $this->db->setQuery($dbquery)->loadResult();
         }


### PR DESCRIPTION
## Summary
Phase 1 of the legacy-view retirement: simplify the site router now that the v2 directory + profile (Phase 0) carry the front end.

**Dropped:**
- The `categories → category → member` view hierarchy and the `home` / `directory` / `featured` flat-view registrations.
- All their segment resolvers: `getCategorySegment`/`getCategoriesSegment`/`getMemberSegment`/`getCategoryId`/`getCategoriesId`/`getMemberId`.

**Kept / added:**
- A single id-keyed **`profile`** route with alias-based SEF (`getProfileSegment`/`getProfileId`) — mirrors the old member resolver, minus the `catid` parent.
- The v2 `members`/`myprofile`/`households` views remain menu-driven (they were never router-registered).

**Constructor contract:** the 4-arg signature stays verbatim. Core `RouterFactory::createRouter` always calls `new Router($app, $menu, $categoryFactory, $db)` **positionally** (no reflection), so the now-unused `CategoryFactoryInterface` param must remain or `$db` would misbind — documented inline.

## Verification
- Profile SEF resolver round-trips on dev data (id 4 ⇄ `brent-cordis-pc-100812893`).
- `composer lint` clean, `composer test` 179 tests / 475 assertions green.

## Next
- **Phase 2**: delete the 6 legacy view stacks (controllers/models/views/tmpl/menu-type XML) + the now-orphaned `RenderHelper`; trash the hidden routing-target menu items.
- **Phase 3**: prune the dead config tabs + language strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)