### PR TITLE
fix(install): don't create a bare 'profile' routing menu item (404 footgun)

### DIFF
--- a/script.php
+++ b/script.php
@@ -165,11 +165,17 @@ class Com_cwmconnectInstallerScript
 
         // v2 front-end views that need a routing-target menu item so the router
         // can build SEF URLs. The legacy member/category/directory/home views
-        // were retired; the directory (members) + per-member profile + the
-        // self-service myprofile are what remain.
+        // were retired; the directory (members) + self-service myprofile are
+        // what remain.
+        //
+        // The per-member `profile` view deliberately gets NO menu item: it's a
+        // detail view reached from the directory and is keyed by `id`. A menu
+        // item of `view=profile` with no id would 404 when opened and — worse —
+        // when the router anchored a profile link on it, it treated the menu
+        // item as the complete profile and dropped the id segment. Profile URLs
+        // route from the directory item instead.
         $views = [
             'members'   => ['title' => 'Church Directory', 'access' => 2],
-            'profile'   => ['title' => 'Member Profile',   'access' => 2],
             'myprofile' => ['title' => 'My Profile',       'access' => 2],
         ];
 


### PR DESCRIPTION
## Bug
Opening the auto-created **Member Profile** menu item (`/…/cwmconnect-profile.html`, `view=profile` with **no id**) 404s — `ProfileModel::getItem(0)` returns false → 'That member could not be found in the directory.' And when the router anchored a real member link on that menu item, it treated the item as the complete profile and **dropped the id segment**, 404-ing logged-in members navigating from the directory too.

## Fix
The per-member `profile` view is a **detail view** reached from the directory and keyed by `id` — it must not have its own routing-target menu item. Drop `profile` from `ensureHiddenMenu()`'s view list (keep **members** = the directory + **myprofile**). Profile URLs route from the directory (`members`) item, with the id in the segment.

Verified the profile URL still builds with the id intact (`/…/profile/4-brent-cordis-pc-100812893.html`). The bare profile menu items already created on the dev installs were trashed.

Syntax clean; install-script change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)