### PR TITLE
chore(deps): cwm/build-tools 1.4.0 → 1.4.1 (media-link fix)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -404,16 +404,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.4.0",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "fb8409262f54290528fa0d162abcdc003b864d51"
+                "reference": "19c9fdbd5bb112127ede278e2de4c38909ba6f53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/fb8409262f54290528fa0d162abcdc003b864d51",
-                "reference": "fb8409262f54290528fa0d162abcdc003b864d51",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/19c9fdbd5bb112127ede278e2de4c38909ba6f53",
+                "reference": "19c9fdbd5bb112127ede278e2de4c38909ba6f53",
                 "shasum": ""
             },
             "require": {
@@ -499,10 +499,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.4.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.4.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-05-15T20:36:27+00:00"
+            "time": "2026-06-04T17:58:11+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
Bumps the dev build tool to **v1.4.1**, which fixes the component media-link derivation for the `<media folder="media/com_cwmconnect">` namespaced layout (cwm-build-tools [#27](https://github.com/Joomla-Bible-Study/cwm-build-tools/pull/27)).

Before, `cwm-link`/`cwm-verify` derived the media source as `<root>/media` instead of `<root>/media/com_cwmconnect`, flagging the *correct* symlink as a conflict (and `--force`-ing would have broken working media).

**Verified:** `composer verify` now reports **22 ok, 0 errors** on both dev installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)