### PR TITLE
chore(config): fix printeddirectory indent + move Permissions tab last

### DIFF
--- a/admin/config.xml
+++ b/admin/config.xml
@@ -223,19 +223,7 @@
 		       description="COM_CWMCONNECT_FIELD_PC_FIELD_LEADER_DESC"
 		       showon="pc_enabled:1"/>
 	</fieldset>
-	<fieldset name="permissions"
-	          label="JCONFIG_PERMISSIONS_LABEL"
-	          description="JCONFIG_PERMISSIONS_DESC"
-	>
-		<field name="rules"
-		       type="rules"
-		       label="JCONFIG_PERMISSIONS_LABEL"
-		       validate="rules"
-		       filter="rules"
-		       component="com_cwmconnect"
-		       section="component"/>
-	</fieldset>
-<fieldset name="printeddirectory"
+	<fieldset name="printeddirectory"
 	          label="COM_CWMCONNECT_FIELD_CONFIG_PRINTED_DIRECTORY"
 	          description="COM_CWMCONNECT_FIELD_CONFIG_PRINTED_DIRECTORY_DESC"
 	>
@@ -419,5 +407,17 @@
 			<option value="large">COM_CWMCONNECT_FIELD_PDF_FONT_SIZE_LARGE</option>
 			<option value="xlarge">COM_CWMCONNECT_FIELD_PDF_FONT_SIZE_XLARGE</option>
 		</field>
+	</fieldset>
+	<fieldset name="permissions"
+	          label="JCONFIG_PERMISSIONS_LABEL"
+	          description="JCONFIG_PERMISSIONS_DESC"
+	>
+		<field name="rules"
+		       type="rules"
+		       label="JCONFIG_PERMISSIONS_LABEL"
+		       validate="rules"
+		       filter="rules"
+		       component="com_cwmconnect"
+		       section="component"/>
 	</fieldset>
 </config>


### PR DESCRIPTION
## Summary

Structural pass over `admin/config.xml`. The bulk of the original "messy config" follow-up was already resolved by #166/#167/#168 — I verified the cruft it was scoped against is gone:

- ✅ no `class="inputbox"`, no `size=` attributes
- ✅ no legacy `dr_show_*` / `con_position` field names
- ✅ "globle" typo already corrected to `global`
- ✅ all 6 fieldset/field language keys resolve (0 missing)
- ℹ️ `class="btn-group"` on `pdf_layout`/`pdf_font_size` is correct (multi-option radios as segmented buttons; the binary radios correctly use `joomla.form.field.radio.switcher`)

That left two genuine structural issues, fixed here:

1. **Indentation** — the `printeddirectory` `<fieldset>` opening tag was missing its leading tab (the only fieldset not indented like the others).
2. **Tab order** — the `permissions` (rules) fieldset sat between *Planning Center* and *Printed Directory*. Joomla convention places **Permissions as the last/rightmost** config tab. Moved it to the end.

New tab order: Directory → Form → Global Member Options → Planning Center → Printed Directory → Permissions.

### Deliberately not changed

Field **names** are persisted param keys read by the component (e.g. `teamleaders` in `RenderHelper`, `protectedaccess` in the visibility logic). Renaming them would be a breaking change requiring a migration for zero functional gain, so they stay as-is.

## Verification

- `php -r 'DOMDocument::load()'` → valid XML
- All `COM_CWMCONNECT_*` config keys resolve against `en-GB/com_cwmconnect.ini` (0 missing)
- `composer test` → 181 tests, 477 assertions, OK
- Diff is whitespace + fieldset relocation only; no field/value/default changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)