### PR TITLE
fix(geocode): re-hydrate the session queue as objects (worker TypeError)

### DIFF
--- a/admin/src/Model/GeoupdateModel.php
+++ b/admin/src/Model/GeoupdateModel.php
@@ -492,9 +492,15 @@ class GeoupdateModel extends BaseDatabaseModel
 
         $decoded = json_decode($stack, true, 512, JSON_THROW_ON_ERROR);
 
-        $this->membersStack = (array) ($decoded['members'] ?? []);
-        $this->totalMembers = (int) ($decoded['total']   ?? 0);
-        $this->doneMembers  = (int) ($decoded['done']    ?? 0);
+        // The queue is JSON-decoded associatively, so each member comes back as
+        // an array; re-hydrate to stdClass to match loadMembers() and the
+        // object-typed update() the worker calls.
+        $this->membersStack = array_map(
+            static fn($member): object => (object) $member,
+            (array) ($decoded['members'] ?? []),
+        );
+        $this->totalMembers = (int) ($decoded['total'] ?? 0);
+        $this->doneMembers  = (int) ($decoded['done']  ?? 0);
 
         return true;
     }


### PR DESCRIPTION
## Summary

Running a geocode pass (after #175 wired up the providers) threw an immediate **HTTP 500**:

```
GeoupdateModel::update(): Argument #1 ($row) must be of type ?object, array given,
called in GeoupdateModel.php (processSlice)
```

The member queue is JSON-serialised to the session between slices and restored with `json_decode(..., true)` (**associative**), so each member came back as an array — but `processSlice` pops it straight into `update(?object $row)`, which also reads `$row->address` etc. as an object. So the worker **never processed a single member** — part of why geocoding had never actually run (alongside the missing API-key config that #175 fixed).

Fix: re-hydrate each restored member to `stdClass` in `loadStack()`.

## Verification
Reproduced the 500 live on j5-dev, applied the fix (live via dev symlink), re-ran: the pass now resolves coordinates (`with_coords` 0 → climbing, with error rows logged for genuinely unresolvable addresses) instead of 500. Lint clean, 201 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)