### PR TITLE
feat(geocode): tidy addresses before lookup + skip already-geocoded on re-run

### DIFF
--- a/admin/src/Model/GeoupdateModel.php
+++ b/admin/src/Model/GeoupdateModel.php
@@ -210,6 +210,16 @@ class GeoupdateModel extends BaseDatabaseModel
 
         if ($id) {
             $query->where($db->quoteName('id') . ' = ' . (int) $id);
+        } else {
+            // Full scan: only members that still need coordinates and actually
+            // have an address — so a re-run retries failures + new members
+            // without re-geocoding everyone or churning on blank addresses.
+            $query->where(
+                '(' . $db->quoteName('lat') . ' = 0 OR ' . $db->quoteName('lng') . ' = 0'
+                . ' OR ' . $db->quoteName('lat') . ' IS NULL OR ' . $db->quoteName('lng') . ' IS NULL)',
+            )
+                ->where($db->quoteName('address') . ' IS NOT NULL')
+                ->where('TRIM(' . $db->quoteName('address') . ") <> ''");
         }
 
         $db->setQuery($query);

--- a/admin/src/Service/Geocode/AddressNormalizer.php
+++ b/admin/src/Service/Geocode/AddressNormalizer.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @package    Cwmconnect.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Administrator\Service\Geocode;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Pure address tidying shared by the geocoders. Street geocoders (Nominatim
+ * especially) miss when an address carries a secondary unit designator
+ * ("Apt 3", "Unit 202", "# 369") or is a PO box (no point to resolve). This
+ * normaliser strips unit designators and drops PO-box street lines so the
+ * lookup falls back to a city/state pin instead of returning nothing.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class AddressNormalizer
+{
+    /**
+     * Secondary-unit keywords kept deliberately unambiguous — common English
+     * words (floor, room, lot) are excluded so real street names survive.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const string UNIT_KEYWORDS = 'apt|apartment|unit|ste|suite|bldg|building|dept|department|spc|space|trlr|trailer';
+
+    /**
+     * Compose a single query string from the parts, after tidying the street.
+     *
+     * @param   string  $street   Street address line.
+     * @param   string  $city     City / suburb.
+     * @param   string  $state    State / region.
+     * @param   string  $country  Country.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function compose(string $street, string $city, string $state, string $country): string
+    {
+        return implode(
+            ', ',
+            array_filter(array_map('trim', [self::cleanStreet($street), $city, $state, $country])),
+        );
+    }
+
+    /**
+     * Tidy a street line: PO boxes collapse to empty (so the caller falls back
+     * to a city/state lookup); unit/apartment/suite designators are removed.
+     *
+     * @param   string  $street  Raw street line.
+     *
+     * @return  string  Cleaned street, or '' for a PO box.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function cleanStreet(string $street): string
+    {
+        $street = trim($street);
+
+        if ($street === '') {
+            return '';
+        }
+
+        if (preg_match('/\bp\.?\s*o\.?\s*box\b/i', $street)
+            || preg_match('/\bpost\s+office\s+box\b/i', $street)) {
+            return '';
+        }
+
+        // Drop "Apt 3" / "Unit 202" / "Ste 100" / "Bldg A" …
+        $street = preg_replace('/\b(?:' . self::UNIT_KEYWORDS . ')\b\.?\s*#?\s*[\w\-]+/i', '', (string) $street);
+
+        // Drop a bare "# 369" style designator.
+        $street = preg_replace('/#\s*[\w\-]+/', '', (string) $street);
+
+        // Tidy doubled spaces and trailing separators.
+        $street = preg_replace('/\s{2,}/', ' ', (string) $street);
+
+        return trim((string) $street, " ,.-\t");
+    }
+}

--- a/admin/src/Service/Geocode/GoogleGeocoder.php
+++ b/admin/src/Service/Geocode/GoogleGeocoder.php
@@ -115,6 +115,6 @@ final readonly class GoogleGeocoder implements GeocoderInterface
      */
     public static function composeAddress(string $street, string $city, string $state, string $country): string
     {
-        return implode(', ', array_filter(array_map('trim', [$street, $city, $state, $country])));
+        return AddressNormalizer::compose($street, $city, $state, $country);
     }
 }

--- a/admin/src/Service/Geocode/NominatimGeocoder.php
+++ b/admin/src/Service/Geocode/NominatimGeocoder.php
@@ -108,7 +108,7 @@ final readonly class NominatimGeocoder implements GeocoderInterface
      */
     public static function composeAddress(string $street, string $city, string $state, string $country): string
     {
-        return implode(', ', array_filter(array_map('trim', [$street, $city, $state, $country])));
+        return AddressNormalizer::compose($street, $city, $state, $country);
     }
 
     /**

--- a/tests/unit/Service/Geocode/AddressNormalizerTest.php
+++ b/tests/unit/Service/Geocode/AddressNormalizerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Service\Geocode;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Geocode\AddressNormalizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the pure address tidying used before a geocode lookup.
+ */
+#[CoversClass(AddressNormalizer::class)]
+final class AddressNormalizerTest extends TestCase
+{
+    /**
+     * @return  array<string, array{0: string, 1: string}>
+     */
+    public static function streetProvider(): array
+    {
+        return [
+            'unit suffix'      => ['5170 Hickory Hollow Pkwy Unit 202', '5170 Hickory Hollow Pkwy'],
+            'apt suffix'       => ['19902 Crystal Rock Dr Apt 302', '19902 Crystal Rock Dr'],
+            'hash suffix'      => ['3486 Highway 155 N # 369', '3486 Highway 155 N'],
+            'suite abbrev'     => ['100 Main St Ste 4', '100 Main St'],
+            'building'         => ['12 Oak Ave Bldg C', '12 Oak Ave'],
+            'po box dropped'   => ['PO Box 981', ''],
+            'po box dotted'    => ['P.O. Box 12', ''],
+            'post office box'  => ['Post Office Box 7', ''],
+            'clean unchanged'  => ['1464 Ohara Dr', '1464 Ohara Dr'],
+            'street word safe' => ['100 Floor Street', '100 Floor Street'],
+            'empty'            => ['  ', ''],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('streetProvider')]
+    public function cleanStreetTidiesUnitsAndPoBoxes(string $input, string $expected): void
+    {
+        self::assertSame($expected, AddressNormalizer::cleanStreet($input));
+    }
+
+    #[Test]
+    public function composeJoinsCleanedPartsAndDropsEmpties(): void
+    {
+        self::assertSame(
+            '5170 Hickory Hollow Pkwy, Antioch, TN, US',
+            AddressNormalizer::compose('5170 Hickory Hollow Pkwy Unit 202', 'Antioch', 'TN', 'US'),
+        );
+    }
+
+    #[Test]
+    public function poBoxFallsBackToCityState(): void
+    {
+        // Street drops out, leaving a city/state pin rather than nothing.
+        self::assertSame(
+            'Hendersonville, TN, US',
+            AddressNormalizer::compose('PO Box 981', 'Hendersonville', 'TN', 'US'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Live-running the geocode pass (after #175 + #176) surfaced **~53% ZERO_RESULTS** — almost all **address quality**, not provider failures:
- Secondary unit designators ("...Unit 202", "...Apt 302", "...# 369") that Nominatim won't match
- PO boxes, which have no point to resolve

### `AddressNormalizer`
A pure helper that:
- **Strips** unit/apartment/suite/building/dept designators and bare `# 369` styles.
- **Drops PO-box** street lines so the lookup falls back to a **city/state pin** instead of returning nothing.
- Keeps the keyword list deliberately unambiguous (floor/room/lot excluded) so real street names survive.

Both geocoders' `composeAddress()` now delegate to it.

### Efficient re-runs
`loadMembers()` (full scan) now selects only members that **still lack coordinates and have an address**, so a re-run retries the failures + new members without re-geocoding everyone or churning on blanks. The single-member (`?id=`) path is unchanged.

## Verification
Against **live** Nominatim, the four representative failures all resolve once normalised:

| Original | Normalised | Result |
|---|---|---|
| 5170 Hickory Hollow Pkwy **Unit 202** | …Pkwy | ✓ |
| 19902 Crystal Rock Dr **Apt 302** | …Dr | ✓ |
| 3486 Highway 155 N **# 369** | …N | ✓ |
| **PO Box 981**, Hendersonville | Hendersonville, TN, US | ✓ |

**214 tests pass** (13 new over the normaliser), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)