### PR TITLE
fix(finder): repair member indexing — catid type + dead getContentPath call

### DIFF
--- a/plugins/finder/cwmconnect/src/Extension/Cwmconnect.php
+++ b/plugins/finder/cwmconnect/src/Extension/Cwmconnect.php
@@ -208,8 +208,7 @@ final class Cwmconnect extends Adapter implements SubscriberInterface
         $item->params  = new Registry($item->params);
 
         $item->url   = $this->getUrl($item->id, $this->extension, $this->layout);
-        $item->route = RouteHelper::getMemberRoute($item->slug, $item->catslug);
-        $item->path  = Helper::getContentPath($item->route);
+        $item->route = RouteHelper::getMemberRoute($item->slug, (int) $item->catid, $item->language);
 
         $title = $this->getItemMenuTitle($item->url);
 


### PR DESCRIPTION
## Summary

Live testing (checklist §13) found that **Smart Search indexing of members was completely broken** — `0 of 531` members indexed. Running the indexer 500'd inside the cwmconnect finder plugin's `index()`. Two J3-leftover bugs:

1. **`catid` type error** — `RouteHelper::getMemberRoute($item->slug, $item->catslug)` passed the category **slug** (a string, and **NULL** whenever a member's category doesn't resolve — i.e. most synced members, who sit at `catid=0`) into the `int $catid` parameter. Under `strict_types` that throws *"Argument #2 ($catid) must be of type int, null given"*, aborting the entire index batch. Now passes `(int) $item->catid` plus the language, matching core's `plgFinderContent`. (`getMemberRoute` doesn't even use `$catid`, but the call still has to type-check.)
2. **Dead `getContentPath` call** — `$item->path = Helper::getContentPath($item->route)` called a method that no longer exists on the Joomla 5 finder `Helper`. Core finder plugins don't set `$item->path` at all (the indexer derives it). Removed.

## Verification (live, j5-dev)
Re-indexed after the fix:
- **530 member links indexed** (was 0) — all members except the one I set `display_in_directory = 0` for the gate test
- That **hidden member is correctly excluded** from the index (0 results)

**214 tests pass, lint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)