### PR TITLE
refactor(geocode): dedupe on the composed query, not the raw address columns

### DIFF
--- a/admin/src/Model/GeoupdateModel.php
+++ b/admin/src/Model/GeoupdateModel.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Cwmconnect\Administrator\Model;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Cwmconnect\Administrator\Service\Geocode\AddressNormalizer;
 use CWM\Component\Cwmconnect\Administrator\Service\Geocode\GeocoderFactory;
 use CWM\Component\Cwmconnect\Administrator\Service\Geocode\GeocoderInterface;
 use Joomla\CMS\Component\ComponentHelper;
@@ -475,12 +476,18 @@ class GeoupdateModel extends BaseDatabaseModel
      * Copy a freshly resolved point onto every other member at the same
      * address who is still missing coordinates.
      *
-     * Households are entered per person, so the same street address recurs
-     * across the directory — 454 members share 322 distinct addresses on the
-     * reference dataset. Geocoding each of them separately buys nothing but
-     * billable lookups, and because providers can return marginally different
-     * points for identical input it also produced households whose members sat
-     * at slightly different pins.
+     * Households are entered per person, so the same place recurs across the
+     * directory — 454 members resolve to 304 distinct queries on the reference
+     * dataset, so a third of the lookups are billable duplicates. Providers
+     * can also return marginally different points for identical input, which
+     * left households sitting on slightly different pins.
+     *
+     * Matching is on {@see AddressNormalizer::compose()} — the exact string
+     * handed to the geocoder — rather than on the raw column values. That
+     * makes the rule true by construction: two members whose addresses compose
+     * identically *must* geocode identically, so copying the point is exact
+     * rather than a guess. It also groups the PO-box lines, which compose away
+     * to a city/state query and therefore genuinely do share one point.
      *
      * Only blank rows are filled: a member who already resolved (or was
      * corrected by hand) is never overwritten by a namesake address.
@@ -495,12 +502,11 @@ class GeoupdateModel extends BaseDatabaseModel
      */
     private function backfillSameAddress(int $memberId, string $latStr, string $lngStr): int
     {
-        $db  = $this->getDatabase();
-        $key = static fn(string $col): string
-            => 'TRIM(LOWER(COALESCE(' . $db->quoteName($col) . ", '')))";
+        $db     = $this->getDatabase();
+        $fields = $db->quoteName(['id', 'address', 'suburb', 'state', 'country']);
 
         $source = $db->createQuery()
-            ->select([$db->quoteName('address'), $db->quoteName('suburb'), $db->quoteName('postcode')])
+            ->select($fields)
             ->from($db->quoteName('#__cwmconnect_details'))
             ->where($db->quoteName('id') . ' = :id')
             ->bind(':id', $memberId, ParameterType::INTEGER);
@@ -511,34 +517,89 @@ class GeoupdateModel extends BaseDatabaseModel
             return 0;
         }
 
-        $address  = trim(strtolower((string) $row->address));
-        $suburb   = trim(strtolower((string) ($row->suburb ?? '')));
-        $postcode = trim(strtolower((string) ($row->postcode ?? '')));
+        $target  = $this->addressKey($row);
+        $suburb  = trim(strtolower((string) ($row->suburb ?? '')));
+        $state   = trim(strtolower((string) ($row->state ?? '')));
+        $country = trim(strtolower((string) ($row->country ?? '')));
 
-        $update = $db->createQuery()
-            ->update($db->quoteName('#__cwmconnect_details'))
-            ->set($db->quoteName('lat') . ' = :lat')
-            ->set($db->quoteName('lng') . ' = :lng')
+        // Narrow in SQL on the parts that are plain column comparisons, then
+        // settle it in PHP on the composed query — compose() collapses unit
+        // designators and PO boxes, which no column comparison can express.
+        $candidates = $db->createQuery()
+            ->select($fields)
+            ->from($db->quoteName('#__cwmconnect_details'))
             ->where($db->quoteName('id') . ' <> :id')
-            ->where($key('address') . ' = :address')
-            ->where($key('suburb') . ' = :suburb')
-            ->where($key('postcode') . ' = :postcode')
+            ->where('TRIM(COALESCE(' . $db->quoteName('address') . ", '')) <> ''")
+            ->where($this->sameText('suburb') . ' = :suburb')
+            ->where($this->sameText('state') . ' = :state')
+            ->where($this->sameText('country') . ' = :country')
             ->where(
                 '(CAST(' . $db->quoteName('lat') . ' AS DECIMAL(12,8)) = 0'
                 . ' OR CAST(' . $db->quoteName('lng') . ' AS DECIMAL(12,8)) = 0'
                 . ' OR ' . $db->quoteName('lat') . ' IS NULL'
                 . ' OR ' . $db->quoteName('lng') . ' IS NULL)',
             )
-            ->bind(':lat', $latStr, ParameterType::STRING)
-            ->bind(':lng', $lngStr, ParameterType::STRING)
             ->bind(':id', $memberId, ParameterType::INTEGER)
-            ->bind(':address', $address, ParameterType::STRING)
             ->bind(':suburb', $suburb, ParameterType::STRING)
-            ->bind(':postcode', $postcode, ParameterType::STRING);
+            ->bind(':state', $state, ParameterType::STRING)
+            ->bind(':country', $country, ParameterType::STRING);
+
+        $matches = [];
+
+        foreach ($db->setQuery($candidates)->loadObjectList() ?: [] as $candidate) {
+            if ($this->addressKey($candidate) === $target) {
+                $matches[] = (int) $candidate->id;
+            }
+        }
+
+        if ($matches === []) {
+            return 0;
+        }
+
+        $update = $db->createQuery()
+            ->update($db->quoteName('#__cwmconnect_details'))
+            ->set($db->quoteName('lat') . ' = :lat')
+            ->set($db->quoteName('lng') . ' = :lng')
+            ->whereIn($db->quoteName('id'), $matches)
+            ->bind(':lat', $latStr, ParameterType::STRING)
+            ->bind(':lng', $lngStr, ParameterType::STRING);
 
         $db->setQuery($update)->execute();
 
         return (int) $db->getAffectedRows();
+    }
+
+    /**
+     * The geocoder query a member row would produce, lowercased for comparison.
+     *
+     * @param   object  $row  Row carrying address / suburb / state / country.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function addressKey(object $row): string
+    {
+        return strtolower(AddressNormalizer::compose(
+            (string) ($row->address ?? ''),
+            (string) ($row->suburb ?? ''),
+            (string) ($row->state ?? ''),
+            (string) ($row->country ?? ''),
+        ));
+    }
+
+    /**
+     * SQL fragment normalising a text column for a case/space-insensitive match.
+     *
+     * @param   string  $column  Column name.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function sameText(string $column): string
+    {
+        return 'TRIM(LOWER(COALESCE(' . $this->getDatabase()->quoteName($column) . ", '')))";
     }
 
     /**

--- a/tests/unit/Service/Geocode/AddressDedupeKeyTest.php
+++ b/tests/unit/Service/Geocode/AddressDedupeKeyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CWM\Component\Cwmconnect\Tests\Service\Geocode;
+
+use CWM\Component\Cwmconnect\Administrator\Service\Geocode\AddressNormalizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The geocode back-fill treats {@see AddressNormalizer::compose()} as its
+ * dedupe key: members whose addresses compose to the same query are given the
+ * same point from a single lookup, instead of each paying for a call.
+ *
+ * That is only sound while compose() equality really does imply "the geocoder
+ * was asked the identical question". These cases pin the two directions that
+ * matter — variations that must collapse (so the saving is real) and
+ * distinctions that must survive (so nobody is put at a neighbour's address).
+ *
+ * @see \CWM\Component\Cwmconnect\Administrator\Model\GeoupdateModel::backfillSameAddress()
+ */
+#[CoversClass(AddressNormalizer::class)]
+final class AddressDedupeKeyTest extends TestCase
+{
+    private function key(string $street, string $city = 'Nashville', string $state = 'TN', string $country = 'USA'): string
+    {
+        return strtolower(AddressNormalizer::compose($street, $city, $state, $country));
+    }
+
+    /**
+     * @return  array<string, array{0: string, 1: string}>
+     */
+    public static function collapsingProvider(): array
+    {
+        return [
+            'unit designator'      => ['120 Oak St Apt 4', '120 Oak St'],
+            'hash designator'      => ['120 Oak St # 4', '120 Oak St'],
+            'suite vs bare'        => ['120 Oak St Suite 200', '120 Oak St'],
+            'trailing whitespace'  => ['120 Oak St ', '120 Oak St'],
+            'case difference'      => ['120 OAK ST', '120 oak st'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('collapsingProvider')]
+    public function variationsOfOneAddressShareAKey(string $a, string $b): void
+    {
+        self::assertSame($this->key($a), $this->key($b));
+    }
+
+    #[Test]
+    public function poBoxesInTheSameTownShareAKey(): void
+    {
+        // Both compose away to the city/state query, so the geocoder returns
+        // one town-level point for each — sharing it is exact, not a guess.
+        self::assertSame($this->key('PO Box 123'), $this->key('P.O. Box 4567'));
+        self::assertSame($this->key('PO Box 123'), 'nashville, tn, usa');
+    }
+
+    /**
+     * @return  array<string, array{0: string, 1: string}>
+     */
+    public static function distinctProvider(): array
+    {
+        return [
+            'different house number' => ['120 Oak St', '122 Oak St'],
+            'different street'       => ['120 Oak St', '120 Elm St'],
+            'number vs none'         => ['120 Oak St', 'Oak St'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('distinctProvider')]
+    public function genuinelyDifferentAddressesKeepDistinctKeys(string $a, string $b): void
+    {
+        self::assertNotSame($this->key($a), $this->key($b));
+    }
+
+    #[Test]
+    public function sameStreetInDifferentTownsStaysDistinct(): void
+    {
+        // The town is part of the key, so a PO box — or any address — in one
+        // town is never given another town's point.
+        self::assertNotSame(
+            $this->key('PO Box 123', 'Nashville'),
+            $this->key('PO Box 123', 'Columbia'),
+        );
+        self::assertNotSame(
+            $this->key('120 Oak St', 'Nashville'),
+            $this->key('120 Oak St', 'Columbia'),
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #181, which introduced the same-address back-fill but keyed it on
raw `address + suburb + postcode`. That only caught addresses typed identically,
which left the obvious duplicates on the table.

## The change

Key on `AddressNormalizer::compose()` — the exact string handed to the geocoder.
That makes the rule true **by construction** rather than by resemblance: two
members whose addresses compose the same *must* geocode the same, so copying the
point is exact, not a guess.

`compose()` is not a column, so the query narrows in SQL on suburb/state/country
and settles the street in PHP — those are the only parts `compose()` rewrites.

## What it buys

On the live dataset: **322 → 304 distinct lookups** across 454 members with an
address (150 saved versus one-per-member, 33%). Two kinds of duplicate that the
raw key missed:

| | Raw key | compose() key |
|---|---|---|
| `PO Box 280872` / `PO Box 331335` / … (5, Nashville) | 5 lookups | 1 |
| `300 Bakertown Rd` / `300 Bakertown Rd Apt 2D` | 2 lookups | 1 |

PO boxes compose away to a city/state query, so they genuinely do resolve to one
town-level point — grouping them is correct, not an approximation.

## Verification

Cleared coordinates for seven rows across three compose-groups the old key would
have split, then re-ran the geocoder: all seven recovered, and each group came
back on exactly one point. The Bakertown pair returned byte-identical
coordinates.

Note the Nashville PO-box group resolved ~600m from its previous centroid — the
same city-level answer, re-fetched. Not a behaviour change, but expected
whenever a city-level pin is refreshed.

**Not proven here:** the runtime reduction in API calls. Old and new code both
produce identical coordinates in this test, because `compose()` is what gets
queried either way — so the observed result cannot discriminate one lookup from
five. The saving follows from the code path (back-fill, then `hasCoordinates()`
skips the row when its turn comes) and the unit tests pin the key semantics, but
the call count was not instrumented. The configured provider is Google, which
does not self-throttle, so timing was not evidence either.

## Tests

12 new cases pin both directions the saving depends on — variations that must
collapse (unit designators, `#`, case, whitespace, PO boxes in one town) and
distinctions that must survive (house number, street name, different towns), so
nobody is placed at a neighbour's address.

228 tests / 545 assertions, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164KUHgk7X5adLVbHMsfraK