### PR TITLE
fix(directory): size the photo grid to the viewport instead of fixed breakpoints

### DIFF
--- a/media/com_cwmconnect/css/cwmconnect.css
+++ b/media/com_cwmconnect/css/cwmconnect.css
@@ -206,3 +206,25 @@ p {
   padding-top: 5px;
 }
 /*# sourceMappingURL=cwmconnect.css.map */
+/* Directory grid.
+ *
+ * Bootstrap's row-cols-* stepped 2 -> 3 -> 4 columns at fixed breakpoints and
+ * then stopped, so past ~992px four cards simply grew to fill the row — around
+ * 320px each, and tall enough with a 3:4 photo that barely two rows fit on a
+ * 1080px-high screen.
+ *
+ * auto-fill + minmax lets the column count follow the available width instead,
+ * so cards keep a roughly constant size and a wider window gains columns rather
+ * than bulk. The clamp sets that size: a floor of 8.5rem keeps two columns on a
+ * phone, it scales with the viewport in between, and the 12rem cap stops a very
+ * wide window drifting back to oversized cards.
+ *
+ * Override --cwm-card-min on the grid or :root to retune; nothing else changes.
+ */
+.cwmconnect-photo-grid {
+  --cwm-card-min: clamp(8.5rem, 16vw, 12rem);
+
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--cwm-card-min), 1fr));
+  gap: 1rem;
+}

--- a/site/tmpl/members/default.php
+++ b/site/tmpl/members/default.php
@@ -25,6 +25,11 @@ $gridActive  = $layoutMode === 'grid' ? ' active' : '';
 $tableActive = $layoutMode === 'table' ? ' active' : '';
 
 $profileLink = static fn(int $id): string => Route::_('index.php?option=com_cwmconnect&view=profile&id=' . $id);
+
+// The component's own front-end stylesheet was registered but never actually
+// requested by any site view, so none of it has been reaching the browser. The
+// directory grid below depends on it.
+$this->getDocument()->getWebAssetManager()->useStyle('com_cwmconnect.directory');
 ?>
 <div class="cwmconnect-members">
     <form action="<?php echo Route::_('index.php?option=com_cwmconnect&view=members'); ?>" method="get" class="row g-2 align-items-end mb-3">
@@ -85,17 +90,15 @@ $profileLink = static fn(int $id): string => Route::_('index.php?option=com_cwmc
             'message' => Text::_('COM_CWMCONNECT_MEMBERS_EMPTY'),
         ]); ?>
     <?php elseif ($layoutMode === 'grid') : ?>
-        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 cwmconnect-photo-grid">
+        <div class="cwmconnect-photo-grid">
             <?php foreach ($this->items as $item) : ?>
-                <div class="col">
-                    <?php echo Layout::render('membercard', [
-                        'id'         => (int) $item->id,
-                        'name'       => trim(($item->name ?: '') ?: ($item->lname ?: '')),
-                        'hasPhoto'   => (string) ($item->image ?? '') !== '',
-                        'profileUrl' => $profileLink((int) $item->id),
-                        'household'  => (string) ($item->household_name ?? ''),
-                    ]); ?>
-                </div>
+                <?php echo Layout::render('membercard', [
+                    'id'         => (int) $item->id,
+                    'name'       => trim(($item->name ?: '') ?: ($item->lname ?: '')),
+                    'hasPhoto'   => (string) ($item->image ?? '') !== '',
+                    'profileUrl' => $profileLink((int) $item->id),
+                    'household'  => (string) ($item->household_name ?? ''),
+                ]); ?>
             <?php endforeach; ?>
         </div>
     <?php else : ?>


### PR DESCRIPTION
Reported as "the cards are quite large on a 1080 screen".

## Cause

`row-cols-2 row-cols-md-3 row-cols-lg-4` stepped to four columns at 992px and
then stopped, so every pixel beyond that went into making the cards bigger
rather than fitting more of them. On a 1080p display that meant ~320px-wide
cards and, with a 3:4 photo, barely two rows above the fold.

## Change

`auto-fill` + `minmax` lets the column count follow the available width, so
cards hold a roughly constant size and a wider window gains columns:

```css
grid-template-columns: repeat(auto-fill, minmax(var(--cwm-card-min), 1fr));
--cwm-card-min: clamp(8.5rem, 16vw, 12rem);
```

The clamp sets that size — an 8.5rem floor keeps two columns on a phone, it
scales with the viewport between, and the 12rem cap stops a very wide window
drifting back to oversized cards. `--cwm-card-min` is exposed for retuning
without touching the rule.

Measured on j5-dev:

| Viewport | Before | After |
|---|---|---|
| 1600x1000 | 4 cols, ~320px | **5 cols, 231x375** |
| 556px | 2 cols | **3 cols, 148px**, no horizontal overflow |

## Two things this turned up

**The front-end stylesheet was never being loaded.** `com_cwmconnect.directory`
is registered in `joomla.asset.json`, but no site view had ever called
`useStyle()` — so none of `cwmconnect.css` was reaching the browser. The members
view now requests it. Without that the new rule silently did nothing and, having
dropped the Bootstrap classes, the grid collapsed to one card per row. **Worth a
look whether other rules in that file have also never applied.**

**The rule went in `cwmconnect.css`, not `general.css`.** `general.css` is
legacy admin styling (`#loading`, `.inlineFields`, `jform_*` overrides) and
loading it on the front end to get one grid rule would drag all of that along.
`cwmconnect.css` is already the front-end directory sheet.

Photo `sizes` is left alone deliberately: the only variants are `thumb 300x400`
and `medium 600x800`, so smaller cards do not change which file is fetched.

Note `site/tmpl/profile/default.php` has its own grid (`row-cols-...-lg-6`) for
household members, left as-is — it is already denser and holds few items.

228 tests / 545 assertions, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164KUHgk7X5adLVbHMsfraK