### PR TITLE
chore(sql): drop demo content from the install, keep only lookup starting data

### DIFF
--- a/admin/language/en-GB/com_cwmconnect.ini
+++ b/admin/language/en-GB/com_cwmconnect.ini
@@ -390,6 +390,7 @@ COM_CWMCONNECT_FIELD_MEMBER_GROUP_DESC="The user group that identifies a real ch
 COM_CWMCONNECT_FIELD_MEMBER_GROUP_NOTE_LABEL="Keeping non-members out"
 COM_CWMCONNECT_FIELD_MEMBER_GROUP_NOTE_DESC="Anyone who registers on the website is Registered, so leaving 'Member view level' at Registered lets every new signup see the full directory. To stop that: create a user group (e.g. 'Church Members') and a view level that only that group can use, select the group above, then set 'Member view level' to the new level. Pairing then grants access, and registering alone does not. Change the view level only once pairing has populated the group, or existing members lose access until it has."
 
+COM_CWMCONNECT_KML_NO_SETTINGS="No published KML settings were found, so there is nothing to build the map from. Create a KML settings record (or publish an existing one) and try the export again."
 COM_CWMCONNECT_FIELD_ACCESS_CODE_ENABLED_LABEL="Shared access code"
 COM_CWMCONNECT_FIELD_ACCESS_CODE_ENABLED_DESC="Let registered users unlock the directory themselves by entering a code you publish, instead of you adding each account to the group by hand. Use this when most of your members have no email address in Planning Center, so pairing can never match them automatically."
 COM_CWMCONNECT_FIELD_ACCESS_CODE_LABEL="Access code"

--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -110,40 +110,6 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_details` (
   DEFAULT COLLATE = utf8mb4_unicode_ci
   AUTO_INCREMENT =4;
 
---
--- Dumping data for table `#__cwmconnect_details`
---
-
-INSERT INTO `#__cwmconnect_details` (`id`, `name`, `lname`, `alias`, `con_position`, `contact_id`, `address`, `suburb`, `state`, `country`, `postcode`, `postcodeaddon`, `telephone`, `fax`, `misc`, `spouse`, `children`, `image`, `imagepos`, `email_to`, `default_con`, `published`, `checked_out`, `checked_out_time`, `ordering`, `params`, `user_id`, `catid`, `kmlid`, `funitid`, `access`, `mobile`, `webpage`, `sortname1`, `sortname2`, `sortname3`, `language`, `created`, `created_by`, `created_by_alias`, `modified`, `modified_by`, `metakey`, `metadesc`, `metadata`, `featured`, `xreference`, `publish_up`, `publish_down`, `skype`, `yahoo_msg`, `lat`, `lng`, `birthdate`, `anniversary`, `attribs`, `version`, `hits`, `surname`)
-VALUES
-  (1, 'Brent Cordis', 'Cordis', 'brent-cordis', '44,35', 0, '2800 Blair Blvd', 'Nashville', 'TN', 'USA', '37212', NULL,
-   '(615) 657-9749', '(615) 657-9749', '', '', 'Child1, Child2', 'images/sampledata/fruitshop/apple.jpg', NULL,
-   'info@joomlabiblestudy.com', 0, 1, 0, '0000-00-00 00:00:00', 1,
-   '{}',
-   NULL, 8, 1, 3, 1, '(615) 657-9749', 'www.joomlabiblestudy.com', 'Last', 'First', 'Middle', '*', '2012-12-03 19:10:08',
-   53, '', '2012-12-06 19:04:09', 53, '', '', '{"robots":"","rights":""}', 0, '', '0000-00-00 00:00:00',
-   '0000-00-00 00:00:00', 'skeebrent', 'bcordis', 36.131973, - 86.812370, '1981-12-03 00:00:00', '2012-12-18 00:00:00',
-   '{"memberstatus":"0","memberotherinfo":"","familypostion":"0","mailingaddress":"","mailingsuburb":"","mailingstate":"","mailingpostcode":"","mailingcountry":""}',
-   1, 0, ''),
-  (2, 'Amy Cordis', 'Cordis', 'amy-cordis', '41', 0, '2800 Blare Blvd', 'Nashville', 'TN', 'USA', '37212', NULL,
-   '(615) 657-9749', '(615) 657-9749', '', '', 'child1, child2', 'images/joomla_black.gif', NULL,
-   'info@joomlabiblestudy.com', 0, 1, 0, '0000-00-00 00:00:00', 2,
-   '{}',
-   NULL, 8, 1, 3, 1, '(615) 657-9749', 'www.joomlabiblestudy.com', '', '', '', '*', '2012-12-05 22:22:32', 53, '',
-   '2012-12-06 19:08:24', 53, '', '', '{"robots":"","rights":""}', 0, '', '0000-00-00 00:00:00', '0000-00-00 00:00:00',
-   'test2', 'test1', 36.131973, - 86.812370, '1976-12-13 00:00:00', '2007-12-25 00:00:00',
-   '{"memberstatus":"0","memberotherinfo":"","familypostion":"1","mailingaddress":"","mailingsuburb":"","mailingstate":"","mailingpostcode":"","mailingcountry":""}',
-   1, 0, ''),
-  (3, 'James Smith', 'Smith', 'james-smith', '32', 0, '999 test St', 'Test', 'TN', 'USA', '99999', NULL,
-   '(XXX) XXX-XXXX', '(XXX) XXX-XXXX', '<p>Demo contact</p>', '', '', 'images/sampledata/fruitshop/apple.jpg', NULL,
-   'info@joomlabiblestudy.com', 0, 1, 0, '0000-00-00 00:00:00', 3,
-   '{}',
-   NULL, 8, 1, 0, 1, '(XXX) XXX-XXXX', 'www.joomlabiblestudy.com', '', '', '', '*', '2012-12-05 22:23:11', 53, '',
-   '2012-12-06 19:10:22', 53, '', '', '{"robots":"","rights":""}', 0, '', '0000-00-00 00:00:00', '0000-00-00 00:00:00',
-   '', '', 0.000000, 0.000000, '1991-07-22 00:00:00', '0000-00-00 00:00:00',
-   '{"memberstatus":"0","memberotherinfo":"","familypostion":"-1","mailingaddress":"","mailingsuburb":"","mailingstate":"","mailingpostcode":"","mailingcountry":""}',
-   1, 0, '');
-
 -- --------------------------------------------------------
 
 --
@@ -197,19 +163,6 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_dirheader` (
   DEFAULT COLLATE = utf8mb4_unicode_ci
   AUTO_INCREMENT =3;
 
---
--- Dumping data for table `#__cwmconnect_dirheader`
---
-
-INSERT INTO `#__cwmconnect_dirheader` (`id`, `name`, `alias`, `description`, `image`, `published`, `checked_out`, `checked_out_time`, `modified`, `modified_by`, `metakey`, `metadesc`, `metadata`, `ordering`, `language`, `created`, `created_by`, `params`, `user_id`, `catid`, `access`, `asset_id`, `publish_up`, `publish_down`)
-VALUES
-  (1, 'Pastor', 'pastor', '<p>Pastor Info coming Soon</p>', 'images/powered_by.png', 1, 0, '0000-00-00 00:00:00',
-   '0000-00-00 00:00:00', 0, '', '', '', 2, '*', '2012-12-05 21:59:23', 53, '', 0, 1, 1, 69, '0000-00-00 00:00:00',
-   '0000-00-00 00:00:00'),
-  (2, 'Our Church Directory', 'our-church-directory', '<p>Church Directory info</p>',
-   'images/sampledata/parks/banner_cradle.jpg', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 1,
-   '*', '2012-12-05 22:00:22', 53, '', 0, 1, 1, 70, '0000-00-00 00:00:00', '0000-00-00 00:00:00');
-
 -- --------------------------------------------------------
 
 --
@@ -252,15 +205,6 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_familyunit` (
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci
   AUTO_INCREMENT =2;
-
---
--- Dumping data for table `#__cwmconnect_familyunit`
---
-
-INSERT INTO `#__cwmconnect_familyunit` (`id`, `name`, `alias`, `description`, `image`, `published`, `checked_out`, `checked_out_time`, `modified`, `modified_by`, `metakey`, `metadesc`, `metadata`, `ordering`, `language`, `created`, `created_by`, `params`, `user_id`, `access`, `asset_id`, `publish_up`, `publish_down`)
-VALUES
-  (1, 'Brent & Amy Cordis', 'brent-amy-cordis', '', '', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '',
-   '', 1, '*', '2012-12-05 22:01:13', 53, '', 0, 1, 71, '0000-00-00 00:00:00', '0000-00-00 00:00:00');
 
 -- --------------------------------------------------------
 
@@ -321,17 +265,6 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_kml` (
   DEFAULT COLLATE = utf8mb4_unicode_ci
   AUTO_INCREMENT =2;
 
---
--- Dumping data for table `#__cwmconnect_kml`
---
-
-INSERT INTO `#__cwmconnect_kml` (`id`, `name`, `alias`, `description`, `published`, `checked_out`, `checked_out_time`, `modified`, `modified_by`, `metakey`, `metadesc`, `metadata`, `ordering`, `language`, `created`, `created_by`, `params`, `linestyle`, `polystyle`, `user_id`, `access`, `asset_id`, `lat`, `lng`, `icon`, `style`, `publish_up`, `publish_down`)
-VALUES
-  (1, 'Nashville First SDA Church Members Directory', 'nashville-first-sda-church-members-directory',
-   '<div>\r\n<p><strong>Confidentiality Notice</strong>: This KML file, including any attachments, is for the sole use of the <strong>Nasvhille First SDA Church Members</strong> and may contain confidential and/or privileged information. If you are not the intended recipient(s), you are hereby notified that any dissemination, unauthorized review, use, disclosure or distribution of this KML file and any materials contained in any attachments is prohibited. If you receive this KML file in error, or are not the intended recipient(s), please immediately notify the sender by email and destroy all copies of the original message, including attachments.Privicy Statment</p>\r\n<div style="text-align: center;">\r\n<p>615-297-1343 | 2800 Blair Blvd | Nashville, TN 37212 <br />webmaster@nfsda.org</p>\r\n</div>\r\n</div>',
-   1, 0, '0000-00-00 00:00:00', '2012-03-18 04:35:11', 63, '', '', '', 0, '*', '2011-12-14 00:00:00', 0,
-   '{"altitude":"0","range":"110027.8255488604","rmaxlines":"","tilt":"0","heading":"-1.119363650863577e-006","lscolormode":"normal","lsscale":".6","icscale":"1.2","open":"1","mcropen":"0","msropen":"0","lscolor":"#ffffff","gxaltitudeMode":"relativeToSeaFloor"}',
-   '00000000', '00000000', 0, 4, 1120, 36.131973, - 86.812370, 'b', '', '2011-12-14 00:00:00', '0000-00-00 00:00:00');
 
 -- --------------------------------------------------------
 
@@ -370,56 +303,6 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_position` (
   DEFAULT COLLATE = utf8mb4_unicode_ci
   AUTO_INCREMENT =31;
 
---
--- Dumping data for table `#__cwmconnect_position`
---
-
-INSERT INTO `#__cwmconnect_position` (`id`, `name`, `alias`, `published`, `checked_out`, `checked_out_time`, `modified`, `modified_by`, `metakey`, `metadesc`, `metadata`, `ordering`, `language`, `created`, `created_by`, `params`, `user_id`, `access`, `asset_id`, `publish_up`, `publish_down`)
-VALUES
-  (1, 'Pastor', 'pastor', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 1, '*',
-   '2012-12-03 21:09:21', 53, '', 0, 1, 37, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(2, 'Elder', 'elder', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 2, '*', '2012-12-03 21:09:36', 53, '', 0, 1, 38, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(3, 'Deacon', 'deacon', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 3, '*', '2012-12-03 21:09:58', 53, '', 0, 1, 39, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(4, 'Deaconess', 'deaconess', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 4, '*', '2012-12-03 21:10:12', 53, '', 0, 1, 40, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(5, 'Clerk', 'clerk', -2, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 5, '*', '2012-12-03 21:10:26', 53, '', 0, 1, 41, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(6, 'Secretary', 'secretary', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 6, '*', '2012-12-03 21:10:57', 53, '', 0, 1, 42, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(7, 'Treasurer', 'treasurer', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 7, '*', '2012-12-03 21:11:13', 53, '', 0, 1, 43, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(8, 'Ass’t Treasurer', 'ass-t-treasurer', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 8, '*', '2012-12-03 21:11:25', 53, '', 0, 1, 44, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(9, 'Head Clerk', 'head-clerk', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 9, '*', '2012-12-03 21:11:41', 53, '', 0, 1, 45, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(10, 'Asst. Clerk', 'asst-clerk', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 10, '*', '2012-12-03 21:12:48', 53, '', 0, 1, 46, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(11, 'Head Deacon', 'head-deacon', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 11, '*', '2012-12-03 21:13:23', 53, '', 0, 1, 47, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(12, 'Head Elder', 'head-elder', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 12, '*', '2012-12-03 21:13:34', 53, '', 0, 1, 48, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(13, 'Head Deaconess', 'head-deaconess', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 13, '*', '2012-12-03 21:13:45', 53, '', 0, 1, 49, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(14, 'Board Member', 'board-member', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 14, '*', '2012-12-03 21:16:56', 53, '', 0, 1, 50, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(15, 'Health & Temperance Department', 'health-temperance-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 15, '*', '2012-12-03 21:17:36', 53, '', 0, 1, 51, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(16, 'AYS Leader', 'ays-leader', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 16, '*', '2012-12-03 21:17:52', 53, '', 0, 1, 52, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(17, 'AYS Helper', 'ays-helper', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 17, '*', '2012-12-03 21:18:12', 53, '', 0, 1, 53, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(18, 'Community Services Department', 'community-services-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 18, '*', '2012-12-03 21:18:33', 53, '', 0, 1, 54, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(19, 'Bulletin', 'bulletin', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 19, '*', '2012-12-03 21:19:06', 53, '', 0, 1, 55, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(20, 'Website', 'website', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 20, '*', '2012-12-03 21:19:15', 53, '', 0, 1, 56, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-(21, 'Prayer Coordinator', 'prayer-coordinator', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 21, '*', '2012-12-03 21:19:27', 53, '', 0, 1, 57, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-  (22, 'Investment Secretary', 'investment-secretary', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '',
-   '', 22, '*', '2012-12-03 21:19:47', 53, '', 0, 1, 58, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-  (23, 'Children''s Ministries Leader', 'children-s-ministries-leader', 1, 0, '0000-00-00 00:00:00',
-   '0000-00-00 00:00:00', 0, '', '', '', 23, '*', '2012-12-03 21:20:25', 53, '', 0, 1, 59, '0000-00-00 00:00:00',
-   '0000-00-00 00:00:00'),
-  (24, 'Children''s Ministries', 'children-s-ministries', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '',
-   '', 24, '*', '2012-12-03 21:20:31', 53, '', 0, 1, 60, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-  (25, 'Sabbath Shool Department Head Superintentdant', 'sabbath-shool-department-head-superintentdant', -2, 0,
-   '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 25, '*', '2012-12-03 21:21:03', 53, '', 0, 1, 61,
-   '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-  (26, 'Sabbath Shool Department', 'sabbath-shool-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0,
-   '', '', '', 26, '*', '2012-12-03 21:21:14', 53, '', 0, 1, 62, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-  (27, 'Personal Ministries Department', 'personal-ministries-department', 1, 0, '0000-00-00 00:00:00',
-   '0000-00-00 00:00:00', 0, '', '', '', 27, '*', '2012-12-03 21:21:32', 53, '', 0, 1, 63, '0000-00-00 00:00:00',
-   '0000-00-00 00:00:00'),
-  (28, 'Music Department', 'music-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 28,
-   '*', '2012-12-03 21:21:51', 53, '', 0, 1, 64, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-  (29, 'Religios Liberty', 'religios-liberty', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 29,
-   '*', '2012-12-03 21:23:28', 53, '', 0, 1, 65, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
-  (30, 'Vacation Bible School', 'vacation-bible-school', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '',
-   '', 30, '*', '2012-12-03 21:23:39', 53, '', 0, 1, 66, '0000-00-00 00:00:00', '0000-00-00 00:00:00');
-
 -- --------------------------------------------------------
 
 --
@@ -435,13 +318,6 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_update` (
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci
   AUTO_INCREMENT =6;
-
---
--- Dumping data for table `#__cwmconnect_update`
---
-
-INSERT INTO `#__cwmconnect_update` (`id`, `version`) VALUES
-  (1, '1.8.2');
 
 -- --------------------------------------------------------
 
@@ -505,3 +381,56 @@ CREATE TABLE IF NOT EXISTS `#__cwmconnect_pc_field_map` (
   ENGINE          = InnoDB
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE = utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Starting data for table `#__cwmconnect_dirheader`
+-- One header block and one footer block for the rendered directory
+-- (`section` 0 = header, 1 = footer). Placeholder wording — every church
+-- will want to reword these, but an empty directory renders with no title
+-- and no notice at all, which is a worse starting point.
+--
+
+INSERT INTO `#__cwmconnect_dirheader` (`id`, `name`, `alias`, `description`, `image`, `published`, `section`, `checked_out`, `checked_out_time`, `modified`, `modified_by`, `metakey`, `metadesc`, `metadata`, `ordering`, `language`, `created`, `created_by`, `params`, `user_id`, `catid`, `access`, `asset_id`, `publish_up`, `publish_down`)
+VALUES
+  (1, 'Our Church Directory', 'our-church-directory', '<p>Welcome to our church directory. Please keep the contact details it contains to yourself and use them only to stay in touch with our members.</p>', NULL, 1, 0, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 1, '*', '0000-00-00 00:00:00', 0, '', 0, 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (2, 'Confidentiality', 'confidentiality', '<p><strong>Confidentiality notice</strong>: this directory is for the sole use of our members. Please do not forward, copy or redistribute it.</p>', NULL, 1, 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 2, '*', '0000-00-00 00:00:00', 0, '', 0, 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00');
+
+-- --------------------------------------------------------
+
+--
+-- Starting data for table `#__cwmconnect_position`
+-- Role vocabulary, not sample content: the Positions list is a lookup an
+-- admin picks from, and an empty one makes the member form unusable until
+-- somebody types all of these in by hand. Edit or delete freely.
+--
+
+INSERT INTO `#__cwmconnect_position` (`id`, `name`, `alias`, `published`, `checked_out`, `checked_out_time`, `modified`, `modified_by`, `metakey`, `metadesc`, `metadata`, `ordering`, `language`, `created`, `created_by`, `params`, `user_id`, `access`, `asset_id`, `publish_up`, `publish_down`)
+VALUES
+  (1, 'Pastor', 'pastor', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 1, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (2, 'Elder', 'elder', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 2, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (3, 'Deacon', 'deacon', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 3, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (4, 'Deaconess', 'deaconess', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 4, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (5, 'Secretary', 'secretary', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 5, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (6, 'Treasurer', 'treasurer', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 6, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (7, 'Asst. Treasurer', 'asst-treasurer', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 7, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (8, 'Head Clerk', 'head-clerk', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 8, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (9, 'Asst. Clerk', 'asst-clerk', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 9, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (10, 'Head Deacon', 'head-deacon', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 10, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (11, 'Head Elder', 'head-elder', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 11, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (12, 'Head Deaconess', 'head-deaconess', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 12, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (13, 'Board Member', 'board-member', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 13, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (14, 'Health & Temperance Department', 'health-and-temperance-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 14, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (15, 'AYS Leader', 'ays-leader', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 15, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (16, 'AYS Helper', 'ays-helper', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 16, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (17, 'Community Services Department', 'community-services-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 17, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (18, 'Bulletin', 'bulletin', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 18, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (19, 'Website', 'website', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 19, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (20, 'Prayer Coordinator', 'prayer-coordinator', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 20, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (21, 'Investment Secretary', 'investment-secretary', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 21, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (22, 'Sabbath School Department', 'sabbath-school-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 22, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (23, 'Personal Ministries Department', 'personal-ministries-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 23, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (24, 'Music Department', 'music-department', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 24, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (25, 'Religious Liberty', 'religious-liberty', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 25, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+  (26, 'Vacation Bible School', 'vacation-bible-school', 1, 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', 0, '', '', '', 26, '*', '0000-00-00 00:00:00', 0, '', 0, 1, NULL, '0000-00-00 00:00:00', '0000-00-00 00:00:00');

--- a/admin/src/Helper/DbHelper.php
+++ b/admin/src/Helper/DbHelper.php
@@ -58,9 +58,16 @@ class DbHelper
     }
 
     /**
-     * Read the configured KML row (id=1) and unpack its params Registry.
+     * Read the KML settings row and unpack its params Registry.
      *
-     * @return  object|null  Returns null if the seed row is missing.
+     * Takes the lowest-id published row rather than `id = 1`. Nothing
+     * guarantees the settings live at id 1: the install ships no rows at all
+     * now, and an admin who deletes the row and creates a replacement gets
+     * whatever id is next. Pinning to 1 meant the map camera and the whole
+     * admin KML export quietly stopped working in both cases, with the id
+     * being the only clue and nothing surfacing it.
+     *
+     * @return  object|null  Null when no published settings row exists.
      *
      * @throws  \Exception
      * @since   2.0.0
@@ -71,7 +78,9 @@ class DbHelper
         $query = $db->createQuery()
             ->select('*')
             ->from($db->quoteName('#__cwmconnect_kml'))
-            ->where($db->quoteName('id') . ' = 1');
+            ->where($db->quoteName('published') . ' = 1')
+            ->order($db->quoteName('id') . ' ASC')
+            ->setLimit(1);
         $db->setQuery($query);
 
         $kml = $db->loadObject();

--- a/admin/src/Helper/ReportbuildHelper.php
+++ b/admin/src/Helper/ReportbuildHelper.php
@@ -21,6 +21,8 @@ use CWM\Component\Cwmconnect\Site\Service\DirectoryPdfPresenter;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
@@ -143,9 +145,13 @@ class ReportbuildHelper
         $kmlInfo  = $dbHelper->getKmlSettings();
 
         if ($kmlInfo === null) {
-            // No KML seed row — bail out silently rather than streaming a
-            // half-built document.
-            Factory::getApplication()->close();
+            // No published KML settings row. Streaming a half-built document
+            // would be worse, but closing without a word leaves the admin
+            // clicking Export and getting a blank tab with nothing to act on —
+            // say what is missing and send them back.
+            $app = Factory::getApplication();
+            $app->enqueueMessage(Text::_('COM_CWMCONNECT_KML_NO_SETTINGS'), 'warning');
+            $app->redirect(Route::_('index.php?option=com_cwmconnect&view=kmls', false));
 
             return;
         }


### PR DESCRIPTION
The install shipped a 2012-era dump: three fake members, two directory headers,
a family unit, and a KML settings row.

## It carried a real organisation's contact details

The KML row held **"Nashville First SDA Church Members Directory"** together
with `615-297-1343`, `2800 Blair Blvd, Nashville TN 37212`, `webmaster@nfsda.org`
and that church's map coordinates — installed verbatim by anyone who installed
the extension. That is the headline reason for this change.

The demo members were also inert rather than merely stale: their column list
predates every v2 column, so `pc_person_id`, `is_child`, `display_in_directory`
and `directory_scope` fell back to defaults — including `access = 0`, which
matches no view level, making them invisible to Smart Search anyway. Their
photos pointed at `images/sampledata/fruitshop/apple.jpg`.

## Removed

Members, directory headers, family unit, KML settings, and the
`#__cwmconnect_update` row — nothing reads that table anywhere, and the manifest
lists it as optional.

## Kept, rewritten

**Positions** and **directory headers**, because these are not sample content:

* Positions is a lookup an admin picks from. Shipping it empty means retyping 26
  roles before the member form is usable.
* The directory renders with no title and no confidentiality notice without the
  header/footer blocks (`section` 0 = header, 1 = footer).

Both reworded to be church-neutral, with typos fixed (`Sabbath Shool`,
`Religios Liberty`, a curly apostrophe in `Ass’t Treasurer`), the two pre-trashed
rows dropped, ids and ordering sequential, and no image paths pointing at Joomla
sample data.

## Two code changes fall out of shipping no KML row

* `DbHelper::getKmlSettings()` pinned to `id = 1`. With no seed row that is never
  satisfied — and it was already fragile: an admin who deleted the row and made a
  new one got a different id, and the map camera plus the entire admin KML export
  silently stopped working with the id as the only clue. Now takes the lowest-id
  **published** row.
* `ReportbuildHelper::getKml()` closed the response without a word when there were
  no settings, so Export produced a blank tab. It now says what is missing and
  returns to the KML list.

## Verified

Applied to a scratch database: 9 tables, 26 positions, 2 directory headers, every
other table empty, no errors. The settings lookup checked in all three states —
no row (null, guarded), a row at id 5 rather than 1 (found, where the old query
returned nothing), and an unpublished row (correctly ignored).

250 tests / 673 assertions, lint clean.

Note this only affects **fresh** installs; existing installs keep whatever rows
they already have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164KUHgk7X5adLVbHMsfraK