### PR TITLE
fix(config): two custom form fields broke the Options screen

### DIFF
--- a/admin/src/Field/AccesscodeField.php
+++ b/admin/src/Field/AccesscodeField.php
@@ -80,13 +80,15 @@ class AccesscodeField extends TextField
                 JS
         );
 
+        $esc = static fn(string $value): string => htmlspecialchars($value, \ENT_QUOTES, 'UTF-8');
+
         return '<div class="input-group">'
             . parent::getInput()
-            . '<button type="button" class="btn btn-secondary" data-cwm-rotate="' . $this->escape($id) . '">'
-            . $this->escape(Text::_('COM_CWMCONNECT_FIELD_ACCESS_CODE_ROTATE'))
+            . '<button type="button" class="btn btn-secondary" data-cwm-rotate="' . $esc($id) . '">'
+            . $esc(Text::_('COM_CWMCONNECT_FIELD_ACCESS_CODE_ROTATE'))
             . '</button>'
             . '</div>'
-            . '<div class="form-text">' . $this->escape($this->statusLine()) . '</div>';
+            . '<div class="form-text">' . $esc($this->statusLine()) . '</div>';
     }
 
     /**

--- a/admin/src/Field/PcMembershipStatusField.php
+++ b/admin/src/Field/PcMembershipStatusField.php
@@ -43,7 +43,18 @@ class PcMembershipStatusField extends CheckboxesField
         $statuses = $this->fetchFromPc();
 
         foreach ($statuses as $status) {
-            $options[] = HTMLHelper::_('select.option', $status, $status);
+            $option = HTMLHelper::_('select.option', $status, $status);
+
+            // `joomla.form.field.checkboxes` reads `$option->checked` directly
+            // rather than through empty(), so an option built straight from
+            // select.option — which only sets value and text — raises
+            // "Undefined property: stdClass::$checked" once per option.
+            // ListField sets this when it builds options from XML; options
+            // added here have to do the same. Always false: nothing is ticked
+            // by default, and an unset membership filter means "sync everyone".
+            $option->checked = false;
+
+            $options[] = $option;
         }
 
         return array_merge(parent::getOptions(), $options);


### PR DESCRIPTION
Both bugs are mine, both from this week, and both only appear when the
component's **Options** screen is rendered — which neither field's testing did.
The access code was verified through the redeem flow end to end; the membership
filter through a sync. Neither exercised the config screen the fields live on.

## 1. `AccesscodeField` fatals Options entirely

```
Call to undefined method CWM\...\Field\AccesscodeField::escape()
  at admin/src/Field/AccesscodeField.php:85
```

`escape()` is an `HtmlView` method; `FormField` has no such thing. Result: every
visit to Options for com_cwmconnect died, so **the component could not be
configured at all** once #183 merged. Replaced with `htmlspecialchars()`.

Checked the neighbours while I was there:

* `LockedmediaField` already uses `htmlspecialchars()` — unaffected
* `VcfView` calls `$this->escape()` but defines its own override for vCard
  escaping — a different method that happens to share a name

## 2. `PcMembershipStatusField` warns once per option

```
Undefined property: stdClass::$checked
  in layouts/joomla/form/field/checkboxes.php on line 73
```

The field builds options with `HTMLHelper::_('select.option', $value, $text)`,
which sets only `value` and `text`. The checkboxes layout reads
`$option->checked` **directly** rather than through `empty()`, so every option
raises a warning — four of them, mid-page, on any install with error display on.

`ListField::getOptions()` sets `checked` when it builds options from XML
(`ListField.php:147-148`); a subclass adding its own options has to do the same.
Always `false` here: nothing is ticked by default, and an unset membership
filter means "sync everyone".

## Verified

On j6-dev with Options open: **zero** warnings of any kind, four membership
checkboxes rendering, access-code field and rotate button both present with the
correct status line ("Active — members can redeem this code now").

250 tests / 673 assertions, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164KUHgk7X5adLVbHMsfraK