### PR TITLE
fix(config): stop long radio labels overlapping their description

### DIFF
--- a/admin/config.xml
+++ b/admin/config.xml
@@ -274,7 +274,6 @@
 
 		<field name="pc_archive_policy"
 		       type="radio"
-		       layout="joomla.form.field.radio.switcher"
 		       default="archive"
 		       label="COM_CWMCONNECT_FIELD_PC_ARCHIVE_POLICY_LABEL"
 		       description="COM_CWMCONNECT_FIELD_PC_ARCHIVE_POLICY_DESC"
@@ -467,7 +466,6 @@
 		</field>
 		<field name="pdf_page_size"
 		       type="radio"
-		       layout="joomla.form.field.radio.switcher"
 		       default="letter"
 		       label="COM_CWMCONNECT_FIELD_PDF_PAGE_SIZE_LABEL"
 		       description="COM_CWMCONNECT_FIELD_PDF_PAGE_SIZE_DESC"


### PR DESCRIPTION
Reported from the Options screen: the "When a person no longer matches" label
and its description were printed on top of each other.

## Cause

`joomla.form.field.radio.switcher` renders a toggle with the active option's
label in a fixed slot beside it. It is built for short paired labels — Yes/No,
Show/Hide. Two fields used it with labels that are sentences:

| Field | Longest label | |
|---|---|---|
| `pc_archive_policy` | `Archive locally (hide from directory, keep the row)` | 51 chars |
| `pdf_page_size` | `Booklet (5.5 × 8.5 in)` | 22 chars |

The text overran the switch and collided with the description underneath.

## Fix

Dropped the layout override so both use the default radio rendering, which puts
each option on its own row and wraps.

Worth saying why I did not just shorten the labels: `pc_archive_policy` decides
whether a member who leaves Planning Center is **hidden or deleted**.
"Archive" / "Delete" alone would not convey that, and it is a destructive
choice — the explanatory labels are doing real work, so the control should fit
them rather than the other way round.

## Audit

Checked all fourteen switcher fields in `config.xml`. The other twelve are
Yes/No, Show/Hide or Enabled/Disabled and are fine. `pdf_color`
("Full colour" / "Black & white") is the longest survivor at 17 characters and
still fits, so it is untouched.

## Verified

On j6-dev: two stacked radios, and the description now begins 5px *below* the
fieldset rather than overlapping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164KUHgk7X5adLVbHMsfraK