### PR TITLE
docs: setup flow from the j6 clean build, plus a setup-assistance design note

### DIFF
--- a/docs/setup-assistance-design.md
+++ b/docs/setup-assistance-design.md
@@ -1,0 +1,218 @@
+# Design: setup assistance (readiness checklist, in-place provisioning, wizard)
+
+Status: **draft for discussion** (2026-07-28). No code.
+Captures the thinking from the j6-dev clean build. Nothing here is decided.
+
+Companion to [`setup-flow.md`](setup-flow.md), which records what setup actually
+requires today.
+
+---
+
+## 1. The problem
+
+Setting the component up is not hard because there are many steps. It is hard
+because of three specific things.
+
+**Failures are silent.** Plugins install disabled, so pairing and Smart Search
+do nothing and look broken. Synced members have no coordinates, so the map is
+empty. No view level is configured, so members cannot see the directory. In
+every case the component *appears* faulty rather than unfinished.
+
+**Order matters, and getting it wrong is punishing.** Setting the member view
+level before pairing has populated the group locks out every existing member.
+Nothing warns you.
+
+**Half the steps throw you out of the component.** Creating the user groups and
+the view level means leaving for `com_users`; enabling the plugins means leaving
+for `com_plugins`. You come back and have to remember where you were, and which
+of the ids you just created goes in which setting.
+
+That last one is the sharpest, because it is the one the component could simply
+stop doing.
+
+---
+
+## 2. Not everyone uses Planning Center
+
+An important constraint, and one `setup-flow.md` currently obscures by assuming
+PC throughout.
+
+`pc_enabled` gates only two things in the entire codebase — whether the Control
+Panel shows the PC card (`Cpanel/HtmlView.php:97`), and whether the PDF cover
+uses PC branding (`PdfView.php:299`). Everything else works without it:
+
+- `PcLockedFields::forItem()` returns an empty list for rows with no
+  `pc_person_id`, so manually created members are **fully editable**
+- `ReconcileModel` is written for the mixed case — *"Manual means
+  `pc_person_id IS NULL` — a row the sync never owns"* — and can merge a manual
+  row into a PC person
+
+So there are three real paths, and any assistance has to branch on the first
+question:
+
+| Path | Shape |
+|---|---|
+| **PC-synced** | Connect, sync, geocode. Most member fields locked. |
+| **Manual** | No PC at all. Members entered by hand, every field editable. The access code matters *more*, since there is no email data to pair on. |
+| **Hybrid** | Synced members plus manual rows, reconciled where they overlap. |
+
+The manual path is shorter but not simpler: it still needs groups, a view level,
+KML settings and geocoding, and it has *no* automatic route into the member
+group, because pairing has nothing to match on.
+
+---
+
+## 3. In-place provisioning
+
+The component should be able to create the Joomla objects setup needs, instead
+of sending the admin to another component to make them and come back with ids.
+
+**There is precedent in this codebase.** `script.php::ensureHiddenMenu()`
+already creates a menu type and menu items directly, idempotently, checking for
+existence first. Provisioning groups and a view level is the same pattern.
+
+**The core tables support it.** `Joomla\CMS\Table\Usergroup::store()` performs
+its own nested-set rebuild, so placement is handled; `ViewLevel::bind()`
+JSON-encodes a rules array. Both are what `com_users` itself uses.
+
+So a single **"Set up directory access"** action could:
+
+1. Create a **Church Members** group, if absent — granted by pairing
+2. Create a **Directory Guests** group, if absent — granted by the access code
+3. Create a **Church Directory** view level listing both, **plus Super Users**
+4. Point `member_group` and `access_code_group` at the new groups
+5. Leave `member_access` alone, and say why (see below)
+
+That collapses the most error-prone part of setup into one reviewable action,
+and removes three classes of mistake seen during this session: forgetting Super
+Users in the view level (which locks administrators out of the front end),
+mismatched group ids between installs, and the ordering trap.
+
+### It must not set the view level for you
+
+`member_access` is the switch that makes the directory members-only. Setting it
+while the group is still empty locks out every existing member. Provisioning
+should create everything and then say plainly: *"Nobody is in these groups yet.
+Once pairing or the access code has populated them, set Member view level to
+Church Directory."*
+
+Do the safe part automatically; make the dangerous part deliberate.
+
+---
+
+## 4. A readiness checklist
+
+More useful than a wizard, and much cheaper, because it keeps earning its keep.
+A wizard answers "how do I set this up?" once. A checklist also answers "why
+can't members see the directory?" six months later — which is the question that
+actually generates support.
+
+Roughly:
+
+```
+✓ Planning Center      connected — 540 members, last synced 2h ago
+✗ Plugins              3 of 5 disabled — pairing and search are inactive
+✗ Geocoding            0 of 540 members have coordinates — the map is empty
+✗ Directory access     no view level set — members cannot see the directory
+✗ Map settings         no KML record — the map has no centre point
+```
+
+Each row is derived from real state, not from a "setup complete" flag — so it
+cannot drift out of sync with reality, and it stays correct if someone later
+disables a plugin or deletes the KML row.
+
+### Three states, not two
+
+Some setup steps need permissions the component does not control:
+
+| Step | Requires |
+|---|---|
+| Enable the bundled plugins | `com_plugins` |
+| Create user groups | `com_users` core.admin |
+| Create view levels | `com_users` core.admin |
+
+None of these are grantable through Church Directory's own `access.xml`. So a
+**Church Directory manager** — `core.manage` on the component, not a Super User
+— cannot finish setup. Showing them a row with a link they will be refused at is
+worse than useless.
+
+Each row therefore needs one of:
+
+- **Done** — with the number that proves it
+- **You can fix this** — with the action
+- **Needs a Super User** — with what to ask for, and no dead link
+
+In-place provisioning (§3) does not remove this constraint, since creating groups
+is itself privileged. It removes the *navigation*, not the permission.
+
+### Related question worth settling separately
+
+`CpanelController::assertAdminAjax()` requires **`core.admin` on
+com_cwmconnect** to run a sync or a geocode. So a directory manager cannot run
+either. That may be deliberate — a sync burns API quota and rewrites every row —
+but if a "directory manager" role is meant to operate the thing day to day, that
+is the line to revisit.
+
+---
+
+## 5. Where it lands
+
+**Deliberately unresolved.** The Control Panel is the obvious home but is due
+for rework, and placement should not be decided before that.
+
+Building the checks as their own view keeps the decision cheap and late: the
+same view can be embedded in the Control Panel, given a menu entry, or surfaced
+through a Joomla post-install message, without changing the logic.
+
+Whatever happens, the state checks themselves are the reusable part — a wizard,
+a checklist and a post-install message would all consume the same handful of
+`isPlanningCenterConnected()` / `pluginsEnabled()` / `hasViewLevel()` answers.
+**Build those first**, decide the presentation later.
+
+---
+
+## 6. Wizard versus checklist
+
+Not either/or, but the checklist should come first.
+
+| | Checklist | Wizard |
+|---|---|---|
+| Useful after setup | yes — it is the diagnostic | no |
+| Cost | low | high |
+| Duplicates existing screens | no | yes |
+| Enforces ordering | by showing what is blocked | actively |
+| Branches on PC / manual | by showing only relevant rows | must, from question one |
+
+A wizard is the better *first-run* experience and worth building once the state
+checks exist and the Control Panel has settled. Joomla 5/6 also ships **Guided
+Tours** natively, which is a cheap complement — it can walk someone through the
+UI, though it cannot check state or prevent the ordering trap, which is where
+the real damage is.
+
+---
+
+## 7. Open questions
+
+1. **Does provisioning create one group or two?** Two is the current design
+   (pairing-managed and code-granted, so `MemberGroupSync` cannot strip a
+   code-granted user). A single group is simpler to explain but reintroduces
+   that conflict.
+2. **Should the checklist offer to enable the plugins?** It can, with
+   `core.admin` — but silently enabling plugins on an admin's site is a bigger
+   liberty than creating an unused group.
+3. **What does the manual path show?** The PC rows should disappear rather than
+   sit there permanently red. Probably keyed on `pc_enabled`, which means asking
+   the question explicitly somewhere.
+4. **Post-install message?** Joomla's own mechanism for "you have installed this,
+   here is what to do next" — good for discovery, and it survives the Control
+   Panel rework.
+5. **Should `core.manage` be able to run a sync?** See §4.
+
+---
+
+## 8. Not in scope
+
+- The Control Panel rework itself
+- Test seed data — see [`test-seed-data-design.md`](test-seed-data-design.md);
+  related, since a wizard demo and a fixture both need believable non-PC data
+- Guided Tour content

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -12,6 +12,31 @@ listed separately in §7 so the happy path stays readable.
 
 ---
 
+---
+
+## 0. Which path are you on
+
+Not every church connects Planning Center, and the answer changes which of the
+steps below apply. `pc_enabled` gates only two things in the whole codebase —
+the Control Panel's PC card and the PDF cover — so the component works fully
+without it.
+
+| Path | Steps that apply |
+|---|---|
+| **PC-synced** | all of them |
+| **Manual** — no Planning Center | skip §2 (connect), §3 (sync). Enter members by hand; every field is editable, because `PcLockedFields` only locks rows that have a `pc_person_id`. |
+| **Hybrid** — synced plus hand-entered | all of them, plus **Reconcile** to merge a manual row into a PC person once they appear in the sync |
+
+Two things the manual path does **not** get away with:
+
+- It still needs groups, a view level, KML settings and geocoding — §4 onward
+  apply unchanged.
+- It has **no automatic route into the member group**, because pairing matches
+  on the email Planning Center holds and there is no PC. The shared access code
+  (§5) is the only self-service way in, so it moves from optional to essential.
+
+---
+
 ## 1. Install
 
 Upload the package through **System → Install → Extensions**. On a symlinked

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -1,0 +1,196 @@
+# Setting up CWM Connect — observed flow
+
+Status: **working notes**, not user documentation (2026-07-28).
+
+Recorded while rebuilding j6-dev from nothing: clean install → Planning Center
+→ sync → working directory. The point is to capture what a real setup actually
+requires, so the eventual user guide describes the product rather than someone's
+memory of it.
+
+Bugs hit along the way are deliberately **excluded** from the steps — they are
+listed separately in §7 so the happy path stays readable.
+
+---
+
+## 1. Install
+
+Upload the package through **System → Install → Extensions**. On a symlinked
+dev checkout use **Discover** instead.
+
+The install creates:
+
+- 9 database tables
+- 26 **Positions** (Pastor, Elder, Deacon … ) — a lookup list, editable
+- 2 **Directory Headers** — a header block and a footer confidentiality notice
+- a hidden site menu type (`cwmconnect-hidden`) with routing targets for
+  `members` and `myprofile`, needed for SEF URLs
+- the admin Components menu entries
+
+It creates **no members, no KML settings and no categories**.
+
+### 1a. Enable the plugins — required
+
+Every bundled plugin installs **disabled**. Nothing warns you.
+
+| Plugin | Needed for |
+|---|---|
+| User – Church Directory Pairing | pairing a member to their Joomla account at registration |
+| Content – Church Directory Pairing | pairing on the other content event |
+| Smart Search – Church Directory | members appearing in site search |
+| Privacy – Church Directory | GDPR export / removal covering member data |
+| Task – CWM Connect Sync | scheduled background syncs (see §7, issue #191) |
+
+The component works without them, but pairing, search and privacy silently do
+nothing — which looks like the feature being broken rather than switched off.
+
+---
+
+## 2. Connect Planning Center
+
+**Options → Planning Center**
+
+1. **Enable Planning Center sync** → Yes
+2. **Client ID** and **Secret** — from a PC Personal Access Token
+   (api.planningcenteronline.com → your app → Personal Access Tokens)
+3. Leave **API base URL** at the default
+4. **Save**
+5. **Test connection** — confirm before going further
+
+### 2a. Reopen Options, then choose membership types
+
+**Membership types to sync** is fetched live from PC, using the **saved**
+credentials. Before the first save it shows a hardcoded fallback
+(Member / Regular Attender / Visitor / Participant), which is usually *not*
+what your PC account defines.
+
+So: save credentials → reload Options → the real list appears → tick the types
+you want → save again.
+
+Leaving all types unticked syncs **everyone** in Planning Center, which is
+rarely what a directory wants. On the reference account this is the difference
+between ~540 members and 797 active people.
+
+### 2b. Decide the archive policy
+
+**When a person no longer matches** — archive locally (hide, keep the row) or
+delete the local row. This decides what happens when someone leaves the church
+or their membership type changes. Worth choosing deliberately.
+
+---
+
+## 3. Sync
+
+**Control Panel → Sync now.**
+
+On the reference dataset the first sync took **415 seconds** for 540 members and
+544 photos, and it runs as a single request — see issue #191 before running this
+on a large congregation.
+
+What the sync brings in:
+
+| | |
+|---|---|
+| Members | names, contact details, addresses, birthdays, gender, membership status |
+| Photos | downloaded and cached locally, with sized web variants |
+| Households | family units, and each member's link to theirs |
+| Campuses | written to Directory Headers, including address and contact details |
+
+What it does **not** bring in: coordinates, categories, positions *assignments*,
+KML settings, or any access configuration.
+
+---
+
+## 4. Geocode
+
+Synced members have addresses but **no coordinates**, so the map is empty until
+this runs.
+
+1. **Options → Geocoding** — choose Nominatim (free, needs a contact email per
+   its usage policy) or Google (needs an API key)
+2. Go to **Geo status** and press **Run geocoding**
+
+Geo status is currently not in the menu — see issue #192. Until that is fixed:
+
+```
+index.php?option=com_cwmconnect&view=geostatus
+```
+
+Members with no address of their own inherit their household's point, and
+addresses that resolve to the same query are only looked up once, so the number
+of API calls is well below the member count.
+
+---
+
+## 5. Decide who may see the directory
+
+The directory is gated by a **view level**, and a view level is granted through
+a **user group**. There are two independent routes into it.
+
+1. Create a user group, e.g. **Church Members** — granted automatically by pairing
+2. Create a second group, e.g. **Directory Guests** — granted by the access code
+3. Create a view level, e.g. **Church Directory**, listing **both** groups —
+   and **Super Users**, or administrators lose front-end access
+4. **Options → Global Member Options**
+   - **Directory member group** → the first group
+   - **Member view level** → the new view level
+5. Optionally **Options → Shared access code**: enable, generate a code, and
+   point **Group granted by the code** at the second group
+
+### Ordering matters here
+
+Set **Member view level** *last*, after pairing has populated the group.
+Switching it first locks out every existing member until the group fills.
+
+### Know the ceiling before relying on pairing
+
+Pairing matches on the email Planning Center holds. On the reference account
+only **160 of 540 (30%)** can ever pair automatically — 316 have no email in PC
+at all, and 64 share one with a housemate (shared emails are refused as
+ambiguous). The shared access code exists to cover the rest.
+
+---
+
+## 6. Remaining setup
+
+- **KML settings** — the install ships none, so the map has no camera position
+  and the admin KML export reports that settings are missing. Create a record
+  under **KML** and set the centre point.
+- **Menu items** — the install creates hidden routing targets; add your own
+  visible menu item pointing at the directory.
+- **Categories** — optional. The directory works fine with everyone
+  uncategorised, which is the current policy.
+- **Positions** — 26 ship as starting data; assign them to members, and edit the
+  list to match your church.
+- **Directory Headers** — reword the shipped header and footer blocks.
+
+---
+
+## 7. Known rough edges
+
+Things that currently make this harder than it should be. Each is tracked:
+
+| | |
+|---|---|
+| [#191](../../issues/191) | Sync runs as one blocking request — times out on shared hosting, and reports failure even when it succeeded |
+| [#192](../../issues/192) | Geo status unreachable from the menu; PC Mappings and Reconcile missing too |
+| [#188](../../issues/188) | Campus data silently discarded on installs missing the `dirheader.pc_*` columns |
+| [#187](../../issues/187) | `details.note` exists only on upgraded installs |
+
+Also worth fixing before this becomes user documentation:
+
+- Plugins installing disabled with no prompt (§1a)
+- Membership types needing a save-and-reload before they populate (§2a)
+- No KML settings row shipped, so the map is uninitialised (§6)
+- Nothing tells an admin the directory is invisible until a view level is
+  configured (§5)
+
+---
+
+## 8. Rough order of operations
+
+```
+install → enable plugins → PC credentials → save → reload
+       → membership types → sync → geocode
+       → groups + view level → populate by pairing/code
+       → set member view level (last) → KML settings → menu item
+```

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -12,8 +12,6 @@ listed separately in §7 so the happy path stays readable.
 
 ---
 
----
-
 ## 0. Which path are you on
 
 Not every church connects Planning Center, and the answer changes which of the


### PR DESCRIPTION
Documentation only — two related notes and no code.

## `docs/setup-flow.md` — what setup actually requires

Written while rebuilding j6-dev from nothing: clean install → Planning Center →
sync → working directory. The point is to record what a real setup needs, so the
eventual user guide describes the product rather than someone's recollection.

Bugs hit on the way are **excluded** from the steps and collected in §7, so the
happy path stays readable while the rough edges stay honest.

Things that cost time and are easy to miss:

* **Every bundled plugin installs disabled**, with no prompt — so pairing, Smart
  Search and privacy coverage silently do nothing, which reads as a broken
  feature rather than an unconfigured one.
* **"Membership types to sync" needs a save and a reload**, because it is fetched
  from PC with the *saved* credentials. Before that it shows a hardcoded fallback
  that usually does not match the account. Leaving it unset syncs everyone — on
  the reference account, ~540 members versus 797 people.
* **Geocoding is a separate step**, from a screen with no menu entry (#192).
* **The view level must be set last**, after pairing has populated the group.
  Setting it first locks out every existing member.

It also records the pairing ceiling up front — only ~30% of members can pair
automatically, because PC holds no email for most of them — since that is *why*
the access code exists and belongs in a guide rather than being discovered later.

**§0 forks on whether Planning Center is used at all.** `pc_enabled` gates only
the Control Panel card and the PDF cover; manual members are fully editable, and
`ReconcileModel` exists for the mixed case. So there are three paths — synced,
manual, hybrid — and the manual one still needs groups, a view level, KML
settings and geocoding, with *no* automatic route into the member group.

## `docs/setup-assistance-design.md` — making it survivable

Draft for discussion, nothing decided.

The framing: setup is hard not because there are many steps, but because
failures are **silent**, order is **punishing**, and half the steps **throw you
out of the component** to create user groups and view levels in `com_users` and
come back holding ids.

That last one the component could stop doing. There is precedent —
`script.php::ensureHiddenMenu()` already provisions menu types and items
idempotently — and the core tables cooperate: `Usergroup::store()` does its own
nested-set rebuild, `ViewLevel::bind()` JSON-encodes a rules array. A single
"Set up directory access" action could create both groups and the view level and
wire the params, removing three mistakes seen this session: omitting Super Users
from the view level, mismatched group ids, and the ordering trap. It should stop
short of setting `member_access`, and say why.

Two constraints from discussion are recorded:

* **Three setup steps need permissions the component does not control** —
  plugins, user groups, view levels. A Church Directory manager (`core.manage`,
  not Super User) cannot finish setup at all. A checklist therefore needs three
  states, the third being *"needs a Super User, here is what to ask for"* rather
  than a link they will be refused at. In-place provisioning removes the
  navigation, not the permission.
* **Placement is left open**, since the Control Panel is due for rework. The
  argument is to build the state checks first as their own view, and decide
  presentation — panel, menu entry, post-install message — later.

Argues for a **state checklist before a wizard**: the checklist keeps earning its
keep as the answer to "why can't members see the directory?" six months on,
which is the question that generates support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164KUHgk7X5adLVbHMsfraK