### PR TITLE
perf(sync): decouple photo fetching from the member sync

### DIFF
--- a/admin/language/en-GB/com_cwmconnect.ini
+++ b/admin/language/en-GB/com_cwmconnect.ini
@@ -668,6 +668,10 @@ COM_CWMCONNECT_PC_SYNC_PARTIAL="Sync completed with errors. See the summary for 
 COM_CWMCONNECT_PC_PROGRESS_PAGE="Processing page %s… %s members so far"
 COM_CWMCONNECT_PC_PROGRESS_SWEEP="Archiving removed members…"
 
+COM_CWMCONNECT_PC_PHOTOS_RUNNING="Fetching member photos — %s checked, %s downloaded. The directory is already usable; you can leave this page and photos resume on the next sync."
+COM_CWMCONNECT_PC_PHOTOS_DONE="Member photos up to date — %s downloaded, %s already cached."
+COM_CWMCONNECT_PC_PHOTOS_FAILED="Members synced, but fetching photos stopped early: %s. Run the sync again to resume."
+
 ; Phase D — PC ↔ Joomla custom-field mappings
 COM_CWMCONNECT_PC_BTN_MAPPINGS="Field mappings"
 COM_CWMCONNECT_PC_BTN_RECONCILE="Reconcile manual rows"

--- a/admin/src/Controller/CpanelController.php
+++ b/admin/src/Controller/CpanelController.php
@@ -123,6 +123,17 @@ class CpanelController extends BaseController
      *
      * @since   __DEPLOY_VERSION__
      */
+    /**
+     * Seconds of work per avatar slice.
+     *
+     * Kept well under the shortest timeout worth defending against (~60s at a
+     * proxy). The engine can only check the clock between pages, so the real
+     * ceiling is this plus one page of downloads — about 13s measured.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const PHOTO_SLICE_SECONDS = 5.0;
+
     public function pcSync(): void
     {
         $this->assertAdminAjax();
@@ -143,10 +154,16 @@ class CpanelController extends BaseController
             // shared runner (the same code path the CLI + scheduled-task plugin
             // use). The progress callback streams page-by-page state to the
             // cache file the pcSyncProgress poll reads.
+            // Photos are excluded deliberately: they were ~400 of the 415
+            // seconds a first sync took, and the browser gave up long before
+            // the server did. The member walk on its own finishes in ~15s for
+            // 540 people, so the directory is usable immediately and the
+            // client then drives pcPhotos() to fill the avatars in. See #191.
             $report = SyncRunner::create()->runFull(
                 function (int $pagesCompleted, int $totalSeen, string $phase) use ($progressFile): void {
                     $this->writeProgress($progressFile, $phase, $pagesCompleted, $totalSeen);
                 },
+                false,
             );
 
             @unlink($progressFile);
@@ -167,6 +184,61 @@ class CpanelController extends BaseController
             );
         } catch (\Throwable $e) {
             @unlink($progressFile);
+            $this->sendJsonAndClose(
+                new JsonResponse(null, $e->getMessage(), true),
+            );
+        }
+    }
+
+    /**
+     * AJAX endpoint: fetch one time-boxed slice of member avatars.
+     *
+     * Called repeatedly by the client after `pcSync` returns, passing back the
+     * `cursor` from the previous response until `done` is true. Each call is
+     * bounded so it cannot outlive a proxy timeout or `max_execution_time` —
+     * which is the whole reason photos no longer run inside the sync.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function pcPhotos(): void
+    {
+        $this->assertAdminAjax();
+
+        // Same reasoning as pcSync(): nothing below writes to the session, and
+        // holding the lock would block the progress poll for the whole slice.
+        $this->app->getSession()->close();
+
+        $cursor = trim((string) $this->input->getString('cursor', ''));
+
+        try {
+            $result = SyncRunner::create()->runPhotoPass(
+                self::PHOTO_SLICE_SECONDS,
+                $cursor !== '' ? $cursor : null,
+            );
+
+            $report = $result['report']->toArray();
+
+            $this->sendJsonAndClose(
+                new JsonResponse(
+                    [
+                        'done'       => $result['nextUrl'] === null,
+                        'cursor'     => $result['nextUrl'],
+                        'pages'      => $result['pages'],
+                        'seen'       => $report['seen'] ?? 0,
+                        'downloaded' => $report['photosDownloaded'] ?? 0,
+                        'unchanged'  => $report['photosUnchanged'] ?? 0,
+                    ],
+                    '',
+                    false,
+                ),
+            );
+        } catch (PcConfigurationException) {
+            $this->sendJsonAndClose(
+                new JsonResponse(null, Text::_('COM_CWMCONNECT_PC_NOT_CONFIGURED'), true),
+            );
+        } catch (\Throwable $e) {
             $this->sendJsonAndClose(
                 new JsonResponse(null, $e->getMessage(), true),
             );

--- a/admin/src/Service/Pc/SyncEngine.php
+++ b/admin/src/Service/Pc/SyncEngine.php
@@ -72,6 +72,21 @@ final class SyncEngine
     private const MAX_PAGES = 200;
 
     /**
+     * Page size for {@see self::runPhotoPass()}.
+     *
+     * Much smaller than the sync's 100, because the time budget can only be
+     * honoured *between* pages — a page is fetched and worked in full before
+     * the clock is consulted again. At roughly 0.7s per avatar download, a
+     * 100-person page is ~70 seconds of work that no budget can interrupt,
+     * which is exactly the timeout this pass exists to avoid. Twelve keeps the
+     * worst-case overrun to about 8 seconds at the cost of a few more API
+     * calls, which are free by comparison.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const PHOTO_PAGE_SIZE = 12;
+
+    /**
      * Includes we pass to PC. `field_data` + `field_data.field_definition`
      * land in Phase D so {@see PersonMapper::extractFieldData()} has the
      * full FieldDatum + its FieldDefinition relationship in `included`.
@@ -163,8 +178,11 @@ final class SyncEngine
      *
      * @since   __DEPLOY_VERSION__
      */
-    public function run(array $membershipStatuses = [], ?\Closure $onProgress = null): SyncReport
-    {
+    public function run(
+        array $membershipStatuses = [],
+        ?\Closure $onProgress = null,
+        bool $includePhotos = true,
+    ): SyncReport {
         $report      = new SyncReport();
         $seenIds     = [];
         $nextUrl     = null;
@@ -234,7 +252,18 @@ final class SyncEngine
                     if ($pcPersonId !== null && $pcPersonId > 0) {
                         $seenIds[] = $pcPersonId;
                         $this->writeCustomFields($pcPersonId, $person, $included, $report);
-                        $this->cacheAvatar($pcPersonId, $person, $report);
+
+                        // Photos are the whole cost of a first sync — 544
+                        // downloads plus variant generation accounted for
+                        // ~400 of the 415 seconds it took to import 540
+                        // members, against 16 seconds for the same members
+                        // with photos already cached. Skipping them here lets
+                        // the directory be usable in seconds; runPhotoPass()
+                        // fills them in afterwards, resumably.
+                        if ($includePhotos) {
+                            $this->cacheAvatar($pcPersonId, $person, $report);
+                        }
+
                         $this->tryPairByEmail($pcPersonId, $attrs, $report);
                     }
                 } catch (\Throwable $e) {
@@ -271,6 +300,117 @@ final class SyncEngine
         $this->logger->info('PC sync finished.', $report->toArray());
 
         return $report;
+    }
+
+    /**
+     * Fetch avatars for people already imported, resumably.
+     *
+     * Split out of {@see self::run()} because photos are the entire cost of a
+     * first sync: importing 540 members took 415 seconds with 544 photos to
+     * fetch, and 16 seconds once they were cached. Running them separately
+     * means the directory is usable within seconds of a sync and the slow part
+     * fills in behind it.
+     *
+     * Re-walks the PC pages rather than reading a queue of pending avatars.
+     * That costs ~16 extra API calls for 800 people — nothing beside the
+     * downloads — and avoids a schema change to carry pending URLs, which
+     * matters while update SQL is not reliably applied to existing installs
+     * (see issue #188). Deciding what to fetch stays exactly where it already
+     * was: {@see MediaPhotoCache::cache()} compares PC's avatar URL against
+     * the stored `image_hash` and returns early when unchanged.
+     *
+     * Stops once `$timeBudget` seconds have elapsed and returns the cursor to
+     * resume from, so no single request outlives a proxy timeout. A caller
+     * that wants the whole thing in one go can pass a large budget.
+     *
+     * @param   float          $timeBudget  Seconds to work for before yielding.
+     * @param   string|null    $resumeUrl   Cursor from a previous call, or null to start.
+     * @param   \Closure|null  $onProgress  fn(int $pagesWalked, int $peopleSeen, string $phase)
+     *
+     * @return  array{report: SyncReport, nextUrl: string|null, pages: int}
+     *          `nextUrl` is null when the walk finished.
+     *
+     * @throws  PcException  Only for fatal transport/auth failures.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function runPhotoPass(
+        float $timeBudget = 10.0,
+        ?string $resumeUrl = null,
+        ?\Closure $onProgress = null,
+    ): array {
+        $report  = new SyncReport();
+        $started = microtime(true);
+        $nextUrl = $resumeUrl;
+        $pages   = 0;
+        $first   = $resumeUrl === null;
+
+        do {
+            if ($pages > self::MAX_PAGES) {
+                $this->logger->warning('PC photo pass hit MAX_PAGES guard.', ['pages' => $pages]);
+                $report->recordError(null, \sprintf('Pagination cap reached at %d pages.', self::MAX_PAGES));
+                $nextUrl = null;
+
+                break;
+            }
+
+            $page = $first
+                ? $this->client->getJson('/people/v2/people', [
+                    'include'       => self::PEOPLE_INCLUDES,
+                    'per_page'      => (string) self::PHOTO_PAGE_SIZE,
+                    'where[status]' => 'active',
+                ])
+                : $this->client->getJsonAbsolute((string) $nextUrl);
+
+            $first = false;
+            $pages++;
+
+            foreach (\is_array($page['data'] ?? null) ? $page['data'] : [] as $person) {
+                if (!\is_array($person)) {
+                    continue;
+                }
+
+                $report->seen++;
+                $pcPersonId = (int) ($person['id'] ?? 0);
+
+                if ($pcPersonId <= 0) {
+                    continue;
+                }
+
+                try {
+                    // Only fetch for people the member sync actually imported.
+                    // PC is walked unfiltered here (the membership filter needs
+                    // the household-discovery pass to be meaningful), so
+                    // without this the pass downloads an avatar for every
+                    // active person in the organisation — 257 wasted downloads
+                    // out of 797 on the reference account, for people who have
+                    // no row to attach them to. The write itself is keyed on
+                    // pc_person_id and would have been a no-op; the download
+                    // is what costs.
+                    if ($this->repository->findIdByPcPersonId($pcPersonId) === null) {
+                        continue;
+                    }
+
+                    $this->cacheAvatar($pcPersonId, $person, $report);
+                } catch (\Throwable $e) {
+                    $report->recordError($pcPersonId, $e->getMessage());
+                    $this->logger->error('PC photo pass error on person.', [
+                        'pcPersonId' => $pcPersonId,
+                        'error'      => $e->getMessage(),
+                    ]);
+                }
+            }
+
+            $nextUrl = $this->extractNextLink($page);
+
+            if ($onProgress !== null) {
+                $onProgress($pages, $report->seen, 'photos');
+            }
+        } while ($nextUrl !== null && (microtime(true) - $started) < $timeBudget);
+
+        $report->finish();
+
+        return ['report' => $report, 'nextUrl' => $nextUrl, 'pages' => $pages];
     }
 
     /**

--- a/admin/src/Service/Pc/SyncRunner.php
+++ b/admin/src/Service/Pc/SyncRunner.php
@@ -78,7 +78,7 @@ final class SyncRunner
      *
      * @since   __DEPLOY_VERSION__
      */
-    public function runFull(?\Closure $onProgress = null): SyncReport
+    public function runFull(?\Closure $onProgress = null, bool $includePhotos = true): SyncReport
     {
         // Auxiliary: refresh campus data (cover church name/address) from PC.
         try {
@@ -87,7 +87,7 @@ final class SyncRunner
             // Campus sync is best-effort; the people sync is the point.
         }
 
-        $report = $this->buildEngine()->run($this->membershipStatuses(), $onProgress);
+        $report = $this->buildEngine()->run($this->membershipStatuses(), $onProgress, $includePhotos);
 
         // Tag members with their church office from the configured PC office
         // lists (Elders, Deacons…). Best-effort.
@@ -102,6 +102,30 @@ final class SyncRunner
         }
 
         return $report;
+    }
+
+    /**
+     * Run one slice of the avatar pass, resuming from `$resumeUrl`.
+     *
+     * Companion to {@see self::runFull()} called with `$includePhotos = false`:
+     * the member sync lands a usable directory in seconds, and this fills the
+     * photos in behind it without any single request running long enough to be
+     * cut off by a proxy or `max_execution_time`.
+     *
+     * @param   float          $timeBudget  Seconds to work for before yielding.
+     * @param   string|null    $resumeUrl   Cursor from the previous slice, or null to start.
+     * @param   \Closure|null  $onProgress  fn(int $pages, int $seen, string $phase)
+     *
+     * @return  array{report: SyncReport, nextUrl: string|null, pages: int}
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function runPhotoPass(
+        float $timeBudget = 10.0,
+        ?string $resumeUrl = null,
+        ?\Closure $onProgress = null,
+    ): array {
+        return $this->buildEngine()->runPhotoPass($timeBudget, $resumeUrl, $onProgress);
     }
 
     /**

--- a/admin/src/View/Cpanel/HtmlView.php
+++ b/admin/src/View/Cpanel/HtmlView.php
@@ -149,6 +149,7 @@ class HtmlView extends BaseHtmlView
             'syncUrl'        => Route::_('index.php?option=com_cwmconnect&task=cpanel.pcSync', false),
             'testUrl'        => Route::_('index.php?option=com_cwmconnect&task=cpanel.pcTestConnection', false),
             'progressUrl'    => Route::_('index.php?option=com_cwmconnect&task=cpanel.pcSyncProgress', false),
+            'photosUrl'      => Route::_('index.php?option=com_cwmconnect&task=cpanel.pcPhotos', false),
             'i18n'           => [
                 'syncing'        => Text::_('COM_CWMCONNECT_PC_SYNCING'),
                 'testing'        => Text::_('COM_CWMCONNECT_PC_TESTING'),
@@ -156,6 +157,9 @@ class HtmlView extends BaseHtmlView
                 'summary'        => Text::_('COM_CWMCONNECT_PC_SUMMARY'),
                 'progressPage'   => Text::_('COM_CWMCONNECT_PC_PROGRESS_PAGE'),
                 'progressSweep'  => Text::_('COM_CWMCONNECT_PC_PROGRESS_SWEEP'),
+                'photosRunning'  => Text::_('COM_CWMCONNECT_PC_PHOTOS_RUNNING'),
+                'photosDone'     => Text::_('COM_CWMCONNECT_PC_PHOTOS_DONE'),
+                'photosFailed'   => Text::_('COM_CWMCONNECT_PC_PHOTOS_FAILED'),
             ],
         ]);
     }

--- a/build/media_source/com_cwmconnect/js/admin-pc-sync.es6.js
+++ b/build/media_source/com_cwmconnect/js/admin-pc-sync.es6.js
@@ -111,8 +111,13 @@
      * Show a spinner + message in the status area.
      *
      * @param {string} message
+     * @param {boolean} [keepResult]  Leave the result panel alone. Used when the
+     *                                photo pass starts, so the member-sync
+     *                                summary the admin just earned stays on
+     *                                screen instead of being wiped by the next
+     *                                spinner.
      */
-    const showSpinner = (message) => {
+    const showSpinner = (message, keepResult = false) => {
         const wrap    = make('div', 'd-inline-flex align-items-center gap-2');
         const spinner = make('span', 'spinner-border spinner-border-sm');
         spinner.setAttribute('aria-hidden', 'true');
@@ -122,7 +127,10 @@
         wrap.appendChild(label);
 
         replaceChildren(status, [wrap]);
-        replaceChildren(result, []);
+
+        if (!keepResult) {
+            replaceChildren(result, []);
+        }
     };
 
     /**
@@ -281,6 +289,79 @@
     };
 
     /**
+     * Fetch member photos in time-boxed slices until done.
+     *
+     * Photos are no longer part of the sync request: they were most of the
+     * ~7 minutes a first import took, and the browser gave up long before the
+     * server finished. The sync now returns as soon as the members are in —
+     * the directory is usable at that point — and this walks the avatars in
+     * afterwards, one short request at a time so nothing hits a timeout.
+     *
+     * Abandoning the page is safe. Anything not yet fetched is simply picked
+     * up by the next sync, because what to download is decided by comparing
+     * Planning Center's avatar URL against the stored hash, not by a queue.
+     *
+     * @returns {Promise<void>}
+     */
+    const fetchPhotos = async () => {
+        let cursor     = '';
+        let checked    = 0;
+        let downloaded = 0;
+        let cached     = 0;
+
+        for (;;) {
+            const body = new FormData();
+            body.append(options.csrfToken, '1');
+            body.append('cursor', cursor);
+
+            let json;
+
+            try {
+                const response = await fetch(options.photosUrl, {
+                    method:      'POST',
+                    credentials: 'same-origin',
+                    body,
+                    headers: { Accept: 'application/json' },
+                });
+
+                json = JSON.parse(await response.text());
+            } catch {
+                showStatus('warning', sprintf(options.i18n.photosFailed, options.i18n.unknownError));
+
+                return;
+            }
+
+            if (!json || json.success === false) {
+                showStatus('warning', sprintf(options.i18n.photosFailed, (json && json.message) || options.i18n.unknownError));
+
+                return;
+            }
+
+            const data = json.data || {};
+
+            checked    += Number(data.seen) || 0;
+            downloaded += Number(data.downloaded) || 0;
+            cached     += Number(data.unchanged) || 0;
+
+            if (data.done) {
+                showStatus('success', sprintf(options.i18n.photosDone, String(downloaded), String(cached)));
+
+                return;
+            }
+
+            cursor = data.cursor || '';
+
+            if (!cursor) {
+                showStatus('success', sprintf(options.i18n.photosDone, String(downloaded), String(cached)));
+
+                return;
+            }
+
+            updateSpinnerText(sprintf(options.i18n.photosRunning, String(checked), String(downloaded)));
+        }
+    };
+
+    /**
      * Handle a click on a `[data-pc-action]` button. Dispatches to the
      * right endpoint and manages the spinner / status / result panels.
      *
@@ -310,6 +391,10 @@
 
         if (action === 'sync' && json.success) {
             renderReport(json.data);
+
+            // Members are in and the directory works; photos fill in behind.
+            showSpinner(sprintf(options.i18n.photosRunning, '0', '0'), true);
+            await fetchPhotos();
         }
     };
 

--- a/docs/setup-assistance-design.md
+++ b/docs/setup-assistance-design.md
@@ -1,0 +1,218 @@
+# Design: setup assistance (readiness checklist, in-place provisioning, wizard)
+
+Status: **draft for discussion** (2026-07-28). No code.
+Captures the thinking from the j6-dev clean build. Nothing here is decided.
+
+Companion to [`setup-flow.md`](setup-flow.md), which records what setup actually
+requires today.
+
+---
+
+## 1. The problem
+
+Setting the component up is not hard because there are many steps. It is hard
+because of three specific things.
+
+**Failures are silent.** Plugins install disabled, so pairing and Smart Search
+do nothing and look broken. Synced members have no coordinates, so the map is
+empty. No view level is configured, so members cannot see the directory. In
+every case the component *appears* faulty rather than unfinished.
+
+**Order matters, and getting it wrong is punishing.** Setting the member view
+level before pairing has populated the group locks out every existing member.
+Nothing warns you.
+
+**Half the steps throw you out of the component.** Creating the user groups and
+the view level means leaving for `com_users`; enabling the plugins means leaving
+for `com_plugins`. You come back and have to remember where you were, and which
+of the ids you just created goes in which setting.
+
+That last one is the sharpest, because it is the one the component could simply
+stop doing.
+
+---
+
+## 2. Not everyone uses Planning Center
+
+An important constraint, and one `setup-flow.md` currently obscures by assuming
+PC throughout.
+
+`pc_enabled` gates only two things in the entire codebase — whether the Control
+Panel shows the PC card (`Cpanel/HtmlView.php:97`), and whether the PDF cover
+uses PC branding (`PdfView.php:299`). Everything else works without it:
+
+- `PcLockedFields::forItem()` returns an empty list for rows with no
+  `pc_person_id`, so manually created members are **fully editable**
+- `ReconcileModel` is written for the mixed case — *"Manual means
+  `pc_person_id IS NULL` — a row the sync never owns"* — and can merge a manual
+  row into a PC person
+
+So there are three real paths, and any assistance has to branch on the first
+question:
+
+| Path | Shape |
+|---|---|
+| **PC-synced** | Connect, sync, geocode. Most member fields locked. |
+| **Manual** | No PC at all. Members entered by hand, every field editable. The access code matters *more*, since there is no email data to pair on. |
+| **Hybrid** | Synced members plus manual rows, reconciled where they overlap. |
+
+The manual path is shorter but not simpler: it still needs groups, a view level,
+KML settings and geocoding, and it has *no* automatic route into the member
+group, because pairing has nothing to match on.
+
+---
+
+## 3. In-place provisioning
+
+The component should be able to create the Joomla objects setup needs, instead
+of sending the admin to another component to make them and come back with ids.
+
+**There is precedent in this codebase.** `script.php::ensureHiddenMenu()`
+already creates a menu type and menu items directly, idempotently, checking for
+existence first. Provisioning groups and a view level is the same pattern.
+
+**The core tables support it.** `Joomla\CMS\Table\Usergroup::store()` performs
+its own nested-set rebuild, so placement is handled; `ViewLevel::bind()`
+JSON-encodes a rules array. Both are what `com_users` itself uses.
+
+So a single **"Set up directory access"** action could:
+
+1. Create a **Church Members** group, if absent — granted by pairing
+2. Create a **Directory Guests** group, if absent — granted by the access code
+3. Create a **Church Directory** view level listing both, **plus Super Users**
+4. Point `member_group` and `access_code_group` at the new groups
+5. Leave `member_access` alone, and say why (see below)
+
+That collapses the most error-prone part of setup into one reviewable action,
+and removes three classes of mistake seen during this session: forgetting Super
+Users in the view level (which locks administrators out of the front end),
+mismatched group ids between installs, and the ordering trap.
+
+### It must not set the view level for you
+
+`member_access` is the switch that makes the directory members-only. Setting it
+while the group is still empty locks out every existing member. Provisioning
+should create everything and then say plainly: *"Nobody is in these groups yet.
+Once pairing or the access code has populated them, set Member view level to
+Church Directory."*
+
+Do the safe part automatically; make the dangerous part deliberate.
+
+---
+
+## 4. A readiness checklist
+
+More useful than a wizard, and much cheaper, because it keeps earning its keep.
+A wizard answers "how do I set this up?" once. A checklist also answers "why
+can't members see the directory?" six months later — which is the question that
+actually generates support.
+
+Roughly:
+
+```
+✓ Planning Center      connected — 540 members, last synced 2h ago
+✗ Plugins              3 of 5 disabled — pairing and search are inactive
+✗ Geocoding            0 of 540 members have coordinates — the map is empty
+✗ Directory access     no view level set — members cannot see the directory
+✗ Map settings         no KML record — the map has no centre point
+```
+
+Each row is derived from real state, not from a "setup complete" flag — so it
+cannot drift out of sync with reality, and it stays correct if someone later
+disables a plugin or deletes the KML row.
+
+### Three states, not two
+
+Some setup steps need permissions the component does not control:
+
+| Step | Requires |
+|---|---|
+| Enable the bundled plugins | `com_plugins` |
+| Create user groups | `com_users` core.admin |
+| Create view levels | `com_users` core.admin |
+
+None of these are grantable through Church Directory's own `access.xml`. So a
+**Church Directory manager** — `core.manage` on the component, not a Super User
+— cannot finish setup. Showing them a row with a link they will be refused at is
+worse than useless.
+
+Each row therefore needs one of:
+
+- **Done** — with the number that proves it
+- **You can fix this** — with the action
+- **Needs a Super User** — with what to ask for, and no dead link
+
+In-place provisioning (§3) does not remove this constraint, since creating groups
+is itself privileged. It removes the *navigation*, not the permission.
+
+### Related question worth settling separately
+
+`CpanelController::assertAdminAjax()` requires **`core.admin` on
+com_cwmconnect** to run a sync or a geocode. So a directory manager cannot run
+either. That may be deliberate — a sync burns API quota and rewrites every row —
+but if a "directory manager" role is meant to operate the thing day to day, that
+is the line to revisit.
+
+---
+
+## 5. Where it lands
+
+**Deliberately unresolved.** The Control Panel is the obvious home but is due
+for rework, and placement should not be decided before that.
+
+Building the checks as their own view keeps the decision cheap and late: the
+same view can be embedded in the Control Panel, given a menu entry, or surfaced
+through a Joomla post-install message, without changing the logic.
+
+Whatever happens, the state checks themselves are the reusable part — a wizard,
+a checklist and a post-install message would all consume the same handful of
+`isPlanningCenterConnected()` / `pluginsEnabled()` / `hasViewLevel()` answers.
+**Build those first**, decide the presentation later.
+
+---
+
+## 6. Wizard versus checklist
+
+Not either/or, but the checklist should come first.
+
+| | Checklist | Wizard |
+|---|---|---|
+| Useful after setup | yes — it is the diagnostic | no |
+| Cost | low | high |
+| Duplicates existing screens | no | yes |
+| Enforces ordering | by showing what is blocked | actively |
+| Branches on PC / manual | by showing only relevant rows | must, from question one |
+
+A wizard is the better *first-run* experience and worth building once the state
+checks exist and the Control Panel has settled. Joomla 5/6 also ships **Guided
+Tours** natively, which is a cheap complement — it can walk someone through the
+UI, though it cannot check state or prevent the ordering trap, which is where
+the real damage is.
+
+---
+
+## 7. Open questions
+
+1. **Does provisioning create one group or two?** Two is the current design
+   (pairing-managed and code-granted, so `MemberGroupSync` cannot strip a
+   code-granted user). A single group is simpler to explain but reintroduces
+   that conflict.
+2. **Should the checklist offer to enable the plugins?** It can, with
+   `core.admin` — but silently enabling plugins on an admin's site is a bigger
+   liberty than creating an unused group.
+3. **What does the manual path show?** The PC rows should disappear rather than
+   sit there permanently red. Probably keyed on `pc_enabled`, which means asking
+   the question explicitly somewhere.
+4. **Post-install message?** Joomla's own mechanism for "you have installed this,
+   here is what to do next" — good for discovery, and it survives the Control
+   Panel rework.
+5. **Should `core.manage` be able to run a sync?** See §4.
+
+---
+
+## 8. Not in scope
+
+- The Control Panel rework itself
+- Test seed data — see [`test-seed-data-design.md`](test-seed-data-design.md);
+  related, since a wizard demo and a fixture both need believable non-PC data
+- Guided Tour content

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -12,6 +12,31 @@ listed separately in §7 so the happy path stays readable.
 
 ---
 
+---
+
+## 0. Which path are you on
+
+Not every church connects Planning Center, and the answer changes which of the
+steps below apply. `pc_enabled` gates only two things in the whole codebase —
+the Control Panel's PC card and the PDF cover — so the component works fully
+without it.
+
+| Path | Steps that apply |
+|---|---|
+| **PC-synced** | all of them |
+| **Manual** — no Planning Center | skip §2 (connect), §3 (sync). Enter members by hand; every field is editable, because `PcLockedFields` only locks rows that have a `pc_person_id`. |
+| **Hybrid** — synced plus hand-entered | all of them, plus **Reconcile** to merge a manual row into a PC person once they appear in the sync |
+
+Two things the manual path does **not** get away with:
+
+- It still needs groups, a view level, KML settings and geocoding — §4 onward
+  apply unchanged.
+- It has **no automatic route into the member group**, because pairing matches
+  on the email Planning Center holds and there is no PC. The shared access code
+  (§5) is the only self-service way in, so it moves from optional to essential.
+
+---
+
 ## 1. Install
 
 Upload the package through **System → Install → Extensions**. On a symlinked

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -1,0 +1,196 @@
+# Setting up CWM Connect — observed flow
+
+Status: **working notes**, not user documentation (2026-07-28).
+
+Recorded while rebuilding j6-dev from nothing: clean install → Planning Center
+→ sync → working directory. The point is to capture what a real setup actually
+requires, so the eventual user guide describes the product rather than someone's
+memory of it.
+
+Bugs hit along the way are deliberately **excluded** from the steps — they are
+listed separately in §7 so the happy path stays readable.
+
+---
+
+## 1. Install
+
+Upload the package through **System → Install → Extensions**. On a symlinked
+dev checkout use **Discover** instead.
+
+The install creates:
+
+- 9 database tables
+- 26 **Positions** (Pastor, Elder, Deacon … ) — a lookup list, editable
+- 2 **Directory Headers** — a header block and a footer confidentiality notice
+- a hidden site menu type (`cwmconnect-hidden`) with routing targets for
+  `members` and `myprofile`, needed for SEF URLs
+- the admin Components menu entries
+
+It creates **no members, no KML settings and no categories**.
+
+### 1a. Enable the plugins — required
+
+Every bundled plugin installs **disabled**. Nothing warns you.
+
+| Plugin | Needed for |
+|---|---|
+| User – Church Directory Pairing | pairing a member to their Joomla account at registration |
+| Content – Church Directory Pairing | pairing on the other content event |
+| Smart Search – Church Directory | members appearing in site search |
+| Privacy – Church Directory | GDPR export / removal covering member data |
+| Task – CWM Connect Sync | scheduled background syncs (see §7, issue #191) |
+
+The component works without them, but pairing, search and privacy silently do
+nothing — which looks like the feature being broken rather than switched off.
+
+---
+
+## 2. Connect Planning Center
+
+**Options → Planning Center**
+
+1. **Enable Planning Center sync** → Yes
+2. **Client ID** and **Secret** — from a PC Personal Access Token
+   (api.planningcenteronline.com → your app → Personal Access Tokens)
+3. Leave **API base URL** at the default
+4. **Save**
+5. **Test connection** — confirm before going further
+
+### 2a. Reopen Options, then choose membership types
+
+**Membership types to sync** is fetched live from PC, using the **saved**
+credentials. Before the first save it shows a hardcoded fallback
+(Member / Regular Attender / Visitor / Participant), which is usually *not*
+what your PC account defines.
+
+So: save credentials → reload Options → the real list appears → tick the types
+you want → save again.
+
+Leaving all types unticked syncs **everyone** in Planning Center, which is
+rarely what a directory wants. On the reference account this is the difference
+between ~540 members and 797 active people.
+
+### 2b. Decide the archive policy
+
+**When a person no longer matches** — archive locally (hide, keep the row) or
+delete the local row. This decides what happens when someone leaves the church
+or their membership type changes. Worth choosing deliberately.
+
+---
+
+## 3. Sync
+
+**Control Panel → Sync now.**
+
+On the reference dataset the first sync took **415 seconds** for 540 members and
+544 photos, and it runs as a single request — see issue #191 before running this
+on a large congregation.
+
+What the sync brings in:
+
+| | |
+|---|---|
+| Members | names, contact details, addresses, birthdays, gender, membership status |
+| Photos | downloaded and cached locally, with sized web variants |
+| Households | family units, and each member's link to theirs |
+| Campuses | written to Directory Headers, including address and contact details |
+
+What it does **not** bring in: coordinates, categories, positions *assignments*,
+KML settings, or any access configuration.
+
+---
+
+## 4. Geocode
+
+Synced members have addresses but **no coordinates**, so the map is empty until
+this runs.
+
+1. **Options → Geocoding** — choose Nominatim (free, needs a contact email per
+   its usage policy) or Google (needs an API key)
+2. Go to **Geo status** and press **Run geocoding**
+
+Geo status is currently not in the menu — see issue #192. Until that is fixed:
+
+```
+index.php?option=com_cwmconnect&view=geostatus
+```
+
+Members with no address of their own inherit their household's point, and
+addresses that resolve to the same query are only looked up once, so the number
+of API calls is well below the member count.
+
+---
+
+## 5. Decide who may see the directory
+
+The directory is gated by a **view level**, and a view level is granted through
+a **user group**. There are two independent routes into it.
+
+1. Create a user group, e.g. **Church Members** — granted automatically by pairing
+2. Create a second group, e.g. **Directory Guests** — granted by the access code
+3. Create a view level, e.g. **Church Directory**, listing **both** groups —
+   and **Super Users**, or administrators lose front-end access
+4. **Options → Global Member Options**
+   - **Directory member group** → the first group
+   - **Member view level** → the new view level
+5. Optionally **Options → Shared access code**: enable, generate a code, and
+   point **Group granted by the code** at the second group
+
+### Ordering matters here
+
+Set **Member view level** *last*, after pairing has populated the group.
+Switching it first locks out every existing member until the group fills.
+
+### Know the ceiling before relying on pairing
+
+Pairing matches on the email Planning Center holds. On the reference account
+only **160 of 540 (30%)** can ever pair automatically — 316 have no email in PC
+at all, and 64 share one with a housemate (shared emails are refused as
+ambiguous). The shared access code exists to cover the rest.
+
+---
+
+## 6. Remaining setup
+
+- **KML settings** — the install ships none, so the map has no camera position
+  and the admin KML export reports that settings are missing. Create a record
+  under **KML** and set the centre point.
+- **Menu items** — the install creates hidden routing targets; add your own
+  visible menu item pointing at the directory.
+- **Categories** — optional. The directory works fine with everyone
+  uncategorised, which is the current policy.
+- **Positions** — 26 ship as starting data; assign them to members, and edit the
+  list to match your church.
+- **Directory Headers** — reword the shipped header and footer blocks.
+
+---
+
+## 7. Known rough edges
+
+Things that currently make this harder than it should be. Each is tracked:
+
+| | |
+|---|---|
+| [#191](../../issues/191) | Sync runs as one blocking request — times out on shared hosting, and reports failure even when it succeeded |
+| [#192](../../issues/192) | Geo status unreachable from the menu; PC Mappings and Reconcile missing too |
+| [#188](../../issues/188) | Campus data silently discarded on installs missing the `dirheader.pc_*` columns |
+| [#187](../../issues/187) | `details.note` exists only on upgraded installs |
+
+Also worth fixing before this becomes user documentation:
+
+- Plugins installing disabled with no prompt (§1a)
+- Membership types needing a save-and-reload before they populate (§2a)
+- No KML settings row shipped, so the map is uninitialised (§6)
+- Nothing tells an admin the directory is invisible until a view level is
+  configured (§5)
+
+---
+
+## 8. Rough order of operations
+
+```
+install → enable plugins → PC credentials → save → reload
+       → membership types → sync → geocode
+       → groups + view level → populate by pairing/code
+       → set member view level (last) → KML settings → menu item
+```

--- a/docs/setup-flow.md
+++ b/docs/setup-flow.md
@@ -12,8 +12,6 @@ listed separately in §7 so the happy path stays readable.
 
 ---
 
----
-
 ## 0. Which path are you on
 
 Not every church connects Planning Center, and the answer changes which of the

--- a/plugins/task/cwmconnect/src/Extension/Cwmconnect.php
+++ b/plugins/task/cwmconnect/src/Extension/Cwmconnect.php
@@ -13,6 +13,7 @@ namespace CWM\Plugin\Task\Cwmconnect\Extension;
 
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\Exception\ConfigurationException;
 use CWM\Component\Cwmconnect\Administrator\Service\Pc\SyncRunner;
+use Joomla\CMS\Application\ConsoleApplication;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Component\Scheduler\Administrator\Event\ExecuteTaskEvent;
 use Joomla\Component\Scheduler\Administrator\Task\Status;
@@ -42,6 +43,20 @@ final class Cwmconnect extends CMSPlugin implements SubscriberInterface
      * @var    array<string, array{langConstPrefix: string}>
      * @since  __DEPLOY_VERSION__
      */
+    /**
+     * Seconds of avatar fetching per slice. Small enough that the budget below
+     * is honoured closely rather than overshot by most of a slice.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private const PHOTO_SLICE_SECONDS = 5.0;
+
+    /** @since __DEPLOY_VERSION__ */
+    private const PHOTO_BUDGET_CLI = 300.0;
+
+    /** @since __DEPLOY_VERSION__ */
+    private const PHOTO_BUDGET_WEB = 20.0;
+
     private const TASKS_MAP = [
         'cwmconnect.sync' => [
             'langConstPrefix' => 'PLG_TASK_CWMCONNECT_SYNC',
@@ -88,8 +103,16 @@ final class Cwmconnect extends CMSPlugin implements SubscriberInterface
 
         $this->startRoutine($event);
 
+        // Photos are excluded here for the same reason the Control Panel
+        // excludes them: they were ~400 of the 415 seconds a first import took.
+        // That matters more for a scheduled run than it looks. Joomla's lazy
+        // scheduler is enabled by default, and it executes tasks inside a web
+        // request — a background fetch fired from a visitor's page, so it does
+        // not delay their browsing, but it is bound by max_execution_time and
+        // occupies a PHP worker for the duration. A seven-minute routine is
+        // killed there long before it finishes.
         try {
-            $report = SyncRunner::create()->runFull();
+            $report = SyncRunner::create()->runFull(null, false);
         } catch (ConfigurationException $e) {
             $this->logTask($e->getMessage(), 'error');
             $this->endRoutine($event, Status::KNOCKOUT);
@@ -102,17 +125,103 @@ final class Cwmconnect extends CMSPlugin implements SubscriberInterface
             return;
         }
 
+        // Fetch what avatars fit in the remaining budget. Nothing is lost by
+        // stopping early: what to download is decided by comparing Planning
+        // Center's avatar URL against the stored hash, so the next run simply
+        // picks up where this one left off without any cursor to persist.
+        $photos = $this->fetchPhotosWithinBudget();
+
         $summary = $report->toArray();
 
         $this->logTask(\sprintf(
-            'CWM Connect sync: seen %d, added %d, updated %d, deleted %d, errors %d.',
+            'CWM Connect sync: seen %d, added %d, updated %d, deleted %d, errors %d. '
+            . 'Photos: %d fetched, %s.',
             (int) ($summary['seen'] ?? 0),
             (int) ($summary['added'] ?? 0),
             (int) ($summary['updated'] ?? 0),
             (int) ($summary['deleted'] ?? 0),
             (int) ($summary['errorCount'] ?? 0),
+            $photos['downloaded'],
+            $photos['done'] ? 'all up to date' : 'more remain for the next run',
         ));
 
         $this->endRoutine($event, $report->success() ? Status::OK : Status::KNOCKOUT);
+    }
+
+    /**
+     * Walk avatar slices until they are done or the budget runs out.
+     *
+     * Nothing is lost by stopping early. What to download is decided by
+     * comparing Planning Center's avatar URL against the stored hash, so the
+     * next run resumes where this one stopped without any cursor to persist —
+     * and under the lazy scheduler there is a next run every few minutes.
+     *
+     * @return  array{downloaded: int, done: bool}
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function fetchPhotosWithinBudget(): array
+    {
+        $started    = microtime(true);
+        $budget     = $this->photoBudget();
+        $cursor     = null;
+        $downloaded = 0;
+        $complete   = false;
+
+        while (microtime(true) - $started < $budget) {
+            try {
+                $slice  = SyncRunner::create()->runPhotoPass(self::PHOTO_SLICE_SECONDS, $cursor);
+                $cursor = $slice['nextUrl'];
+                $downloaded += (int) ($slice['report']->toArray()['photosDownloaded'] ?? 0);
+            } catch (\Throwable $e) {
+                // The members are already committed; a photo failure must not
+                // fail the task, or a working sync reports as broken.
+                $this->logTask('CWM Connect photo pass stopped: ' . $e->getMessage(), 'warning');
+
+                return ['downloaded' => $downloaded, 'done' => false];
+            }
+
+            if ($cursor === null) {
+                // A null cursor means the last page was reached, not that the
+                // loop was skipped — the distinction matters, because with no
+                // budget left the loop never runs and $cursor is null having
+                // fetched nothing.
+                $complete = true;
+                break;
+            }
+        }
+
+        return ['downloaded' => $downloaded, 'done' => $complete];
+    }
+
+    /**
+     * How long the photo phase may run, in seconds.
+     *
+     * From the CLI there is no request to outlive, so a first import can make
+     * real progress in one go. In a web request the ceiling is whatever is left
+     * of max_execution_time — measured from the start of the request, since the
+     * member sync has already spent part of it — less a slice's worth of
+     * headroom so the budget expires before PHP does.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function photoBudget(): float
+    {
+        if ($this->getApplication() instanceof ConsoleApplication) {
+            return self::PHOTO_BUDGET_CLI;
+        }
+
+        $limit = (int) ini_get('max_execution_time');
+
+        if ($limit <= 0) {
+            // Unlimited, which is normal under php-fpm. The web ceiling still
+            // applies: this is a shared worker, not a dedicated process.
+            return self::PHOTO_BUDGET_WEB;
+        }
+
+        $elapsed   = microtime(true) - (float) ($_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true));
+        $remaining = $limit - $elapsed - self::PHOTO_SLICE_SECONDS;
+
+        return max(0.0, min(self::PHOTO_BUDGET_WEB, $remaining));
     }
 }


### PR DESCRIPTION
The first Planning Center import took **415 seconds** for 540 members — and ~400 of those were avatar downloads, at roughly 0.77s each. That is fine for our 540; it is not fine for a congregation several times larger, and it ran as a single blocking request.

Photos are now a separate, resumable phase in both places that sync.

## Control Panel

`Sync now` fetches members only (~15s on the reference dataset), then the browser drives photo slices over AJAX with progress, so the admin sees movement instead of a spinner that may or may not be alive.

## Scheduled task

The task plugin had kept the old inline behaviour, which made the two paths diverge — and the scheduled path is the worse place for a long run. Joomla's lazy scheduler is on by default and executes tasks **in a web request**: a background `fetch()` fired from a visitor's page. It does not delay their browsing, but it is bound by `max_execution_time` and occupies a PHP worker.

So the task now syncs members, then fetches avatars in 5s slices until a budget expires:

| Context | Budget |
|---|---|
| CLI | 300s — no request to outlive |
| Web | remaining `max_execution_time` less a slice of headroom, capped at 20s |

Stopping early loses nothing. What to download is decided by comparing PC's avatar URL against the stored `image_hash`, so the next run resumes without any cursor to persist — and under the lazy scheduler there is a next run every few minutes.

## Verification

Against j5-dev with 540 real members:

- member sync alone: ~15s, 0 photos
- photo pass, CLI budget: completes, `done=true`
- photo pass, web budget: stops at ~20s, `done=false`
- exhausted budget: runs nothing, `done=false` — an earlier `do...while` fired one more slice past the limit, and then reported `done=true` having attempted nothing
- full `runSync()` through a real `ExecuteTaskEvent`: 36.9s, exit status `OK`

`composer lint` clean, 250 tests pass.

## Noticed while testing

j5-dev has 4 of the 5 bundled plugins registered — `plg_task_cwmconnect` was never discovered there, so scheduled sync has never actually been installed on it. j6-dev, rebuilt clean, has all 5. A Discover run on j5 fixes it; no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164KUHgk7X5adLVbHMsfraK