### PR TITLE
chore(ci): wire the cwm-build-tools lint checks into check and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,22 @@ jobs:
       - name: Check PHP syntax (admin/src + site/src + modules + plugins)
         run: composer lint:syntax
 
+      # The four checks below come from cwm/build-tools and are structural:
+      # what a query builder call, a comment or a path filter says does not
+      # vary by PHP version. If this job is ever split into a J5 x J6 matrix,
+      # they belong in one leg only, not duplicated per version.
+      - name: Check query builder usage ($db->createQuery)
+        run: composer lint-queries
+
+      - name: Check for Joomla 6/7 deprecations
+        run: composer lint-deprecations
+
+      - name: Check for issue references in comments
+        run: composer lint-comments
+
+      - name: Check workflow path filters resolve
+        run: composer lint-workflows
+
       - name: Check coding standards (php-cs-fixer)
         run: composer lint
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,12 @@ composer install                 # PSR-4 autoload + dev tooling (cwm/build-tools
 composer lint:syntax             # parallel php -l across admin/src + site/src + modules + plugins
 composer lint                    # php-cs-fixer dry-run
 composer lint:fix                # php-cs-fixer write
-composer test                    # phpunit (no tests yet — phase 8)
-composer check                   # lint:syntax + lint + test
+composer lint-queries            # $db->createQuery() over $db->getQuery(true)
+composer lint-deprecations       # Joomla 6/7 upgrade blockers (bootstrap.modal, jQuery, Joomla.Modal)
+composer lint-comments           # issue numbers don't belong in comments — git blame already links them
+composer lint-workflows          # CI path filters that match no tracked file (fails closed: job silently skipped)
+composer test                    # phpunit (250 tests under tests/unit/)
+composer check                   # lint:syntax + the four lint-* checks + lint + test
 composer build                   # pkg_cwmconnect zip (stub — see phase 1d note)
 composer release                 # full 8-step pipeline via cwm-release (phase 9 prerequisites needed)
 composer bump-version            # cwm-bump (phase 9 prerequisites needed)

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,13 @@
         "lint":            "php-cs-fixer fix --dry-run --diff",
         "lint:fix":        "php-cs-fixer fix",
         "lint:syntax":     "find admin/src site/src modules plugins -type f -name '*.php' -print0 2>/dev/null | xargs -0 -n 1 -P 8 php -l > /dev/null",
-        "check":           ["@lint:syntax", "@lint", "@test"],
+
+        "lint-queries":      "cwm-lint-queries",
+        "lint-deprecations": "cwm-lint-deprecations",
+        "lint-comments":     "cwm-lint-comments",
+        "lint-workflows":    "cwm-lint-workflows",
+
+        "check":           ["@lint:syntax", "@lint-queries", "@lint-deprecations", "@lint-comments", "@lint-workflows", "@lint", "@test"],
         "release":         "cwm-release",
         "bump-version":    "cwm-bump",
         "package":         "cwm-package",


### PR DESCRIPTION
Follow-up to #197. The build-tools bump to v1.32.0 brought four structural linters that nothing was calling.

## What each one guards

| check | guards |
|---|---|
| `cwm-lint-queries` | `$db->createQuery()` over `$db->getQuery(true)` — the phase M sweep took this 62 → 0 by hand |
| `cwm-lint-deprecations` | J6/J7 blockers (`bootstrap.modal`, `Joomla.Modal`, jQuery) that the J6-native rule in CLAUDE.md forbids |
| `cwm-lint-comments` | issue numbers in comments; `git blame` already links a line to its commit, PR and issue |
| `cwm-lint-workflows` | CI path filters matching no tracked file |

That last one is the reason this PR is worth more than tidiness. A stale `paths:` entry **fails closed** — the job never triggers and the PR goes green anyway, indistinguishable in review from a filter that works. Per the tool's own docs that has bitten the CWM repos five times. This repo hit the same class of failure in #197 itself: a conflicted base meant CI never ran at all and the PR simply showed no checks.

## Decisions

**Hard gates, not `--warn`.** All four pass on the current tree, so there's no backlog to grandfather, and `--warn` on a clean check is a gate that never fires.

**Naming: `lint-*` for shared binaries, `lint:*` for project-local scripts.** Follows the tools' own `--help` text and the `lint-workflows` alias already in Proclaim and CWMLivingWord. Proclaim's `lint:queries`/`lint:comments` are colon-style because they're local scripts (`build/lint-queries.sh`) that predate the shared binaries — not a counter-convention.

**No `lint.paths` block.** Defaults track the conventional Joomla source roots filtered to those that exist, so a source root added later is picked up automatically. Pinning the list would fail closed the same way a stale `paths:` filter does — the exact failure `lint-workflows` exists to catch. All three sibling repos likewise have no `lint` block.

**Discrete CI steps, not one `composer check` call.** A failure gets annotated to the check that found it, matching how the existing syntax/standards/test steps are laid out and how Proclaim wires `lint:queries`. They sit before php-cs-fixer, being faster and structural. Note added that these don't vary by PHP version, should this job ever split into the J5 × J6 matrix from phase 8.

## Verification

- `composer check` green end to end — all four linters clean, 0 of 266 files to fix, 250 tests / 673 assertions
- **the gate actually gates**: a planted `// probe #1234` exits 1, removing it exits 0
- **`lint-comments` checked against this project's date convention before hard-gating it** — dates (`2026-08-21`), version strings (`2.0.0`, `1.8.3`, `PHP 8.4`) and dated SQL filenames (`4.0.0-2026-08-21.sql`) are all ignored; only a real `#1234` is flagged

CLAUDE.md documents the four commands, and its `composer test` line no longer claims there are no tests yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)